### PR TITLE
Fix deployment strategy of Nexus

### DIFF
--- a/nexus/ocp-config/dc.yml
+++ b/nexus/ocp-config/dc.yml
@@ -21,13 +21,9 @@ objects:
     strategy:
       activeDeadlineSeconds: 21600
       resources: {}
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
+      recreateParams:
         timeoutSeconds: 600
-        updatePeriodSeconds: 1
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         annotations: {}


### PR DESCRIPTION
It cannot be rolling because it mounts a volume in
ReadWriteOnce access mode.