### PR TITLE
Set Jenkins URL during initialization

### DIFF
--- a/jenkins/master/configuration/init.groovy.d/url.groovy
+++ b/jenkins/master/configuration/init.groovy.d/url.groovy
@@ -1,0 +1,5 @@
+import jenkins.model.JenkinsLocationConfiguration
+def jlc = jenkins.model.JenkinsLocationConfiguration.get()
+def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text
+def host = "oc get route jenkins -n ${namespace} -o 'jsonpath={.spec.host}'".execute().text
+jlc.setUrl("https://${host}")

--- a/jenkins/master/configuration/init.groovy.d/url.groovy
+++ b/jenkins/master/configuration/init.groovy.d/url.groovy
@@ -1,6 +1,8 @@
 import jenkins.model.JenkinsLocationConfiguration
 def jlc = jenkins.model.JenkinsLocationConfiguration.get()
-def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text
-def host = "oc get route jenkins -n ${namespace} -o 'jsonpath={.spec.host}'".execute().text
+def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text.trim()
+println "INFO: JenkinsLocationConfiguration - namespace of pod is: ${namespace}"
+def host = "oc get route jenkins -n ${namespace} -o jsonpath={.spec.host}".execute().text.trim()
+println "INFO: JenkinsLocationConfiguration - route to jenkins is: ${host}"
 jlc.setUrl("https://${host}")
 jlc.save()

--- a/jenkins/master/configuration/init.groovy.d/url.groovy
+++ b/jenkins/master/configuration/init.groovy.d/url.groovy
@@ -3,3 +3,4 @@ def jlc = jenkins.model.JenkinsLocationConfiguration.get()
 def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text
 def host = "oc get route jenkins -n ${namespace} -o 'jsonpath={.spec.host}'".execute().text
 jlc.setUrl("https://${host}")
+jlc.save()


### PR DESCRIPTION
Otherwise, no URL will be configured, which leads to an empty BUILD_URL
until the configuration is saved in the UI.

Fixes https://github.com/opendevstack/ods-jenkins-shared-library/issues/40.

@rattermeyer Can you verify that this works for you as well? Keep in mind that this only works out-of-the-box for new Jenkins instances. For existing ones, you need to copy the file into the volume to be picked up on the next boot.