### PR TITLE
Fix pipeline name

### DIFF
--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -206,13 +206,20 @@ func (s *Server) HandleRoot() http.HandlerFunc {
 		}
 		pipeline := component + "-"
 
-		// Extract JIRA user story from branch name if present
-		re := regexp.MustCompile(".*-([0-9]+)-.*")
-		matches := re.FindStringSubmatch(branch)
+		// Extract ticket ID from branch name if present
+		lowercaseBranch := strings.ToLower(branch)
+		lowercaseProject := strings.ToLower(project)
+		ticketRegex := regexp.MustCompile(".*" + lowercaseProject + "-([0-9]+)-.*")
+		matches := ticketRegex.FindStringSubmatch(lowercaseBranch)
 		if len(matches) > 0 {
 			pipeline = pipeline + matches[1]
 		} else {
-			pipeline = pipeline + strings.Replace(strings.ToLower(branch), "/", "-", -1)
+			// Cut all non-alphanumeric characters
+			safeCharsRegex := regexp.MustCompile("[^-a-zA-Z0-9]+")
+			pipeline = pipeline + safeCharsRegex.ReplaceAllString(
+				strings.Replace(lowercaseBranch, "/", "-", -1),
+				"",
+			)
 		}
 
 		event := &Event{

--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -209,7 +209,7 @@ func (s *Server) HandleRoot() http.HandlerFunc {
 		// Extract ticket ID from branch name if present
 		lowercaseBranch := strings.ToLower(branch)
 		lowercaseProject := strings.ToLower(project)
-		ticketRegex := regexp.MustCompile(".*" + lowercaseProject + "-([0-9]+)-.*")
+		ticketRegex := regexp.MustCompile(".*" + lowercaseProject + "-([0-9]+)")
 		matches := ticketRegex.FindStringSubmatch(lowercaseBranch)
 		if len(matches) > 0 {
 			pipeline = pipeline + matches[1]


### PR DESCRIPTION
* Regexes are greedy, so we need to be more specific when looking for
  the ticket ID (previously we got the last number in the string, not
  necessarily the ticket ID).
* Safer regex for the branch name (remove all problematic characters).

Fixes #59.