### PR TITLE
Delete associated builds in the background

### DIFF
--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -323,7 +323,7 @@ func (c *Client) CreatePipelineIfRequired(e *Event) error {
 // OpenShift.
 func (c *Client) DeletePipeline(e *Event) error {
 	url := fmt.Sprintf(
-		"%s/namespaces/%s/buildconfigs/%s",
+		"%s/namespaces/%s/buildconfigs/%s?propagationPolicy=Background",
 		c.OpenShiftAPIBaseURL,
 		e.Namespace,
 		e.Pipeline,


### PR DESCRIPTION
This prevents builds from being orphaned, see:
- https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
- https://docs.openshift.com/container-platform/3.11/rest_api/apis-build.openshift.io/v1.BuildConfig.html#Delete-apis-build.openshift.io-v1-namespaces-namespace-buildconfigs-name

Fixes #72.