### PR TITLE
Delete associated builds in the foreground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .project
+.vscode
 *.env

--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -322,7 +322,7 @@ func (c *Client) CreatePipelineIfRequired(e *Event) error {
 // OpenShift.
 func (c *Client) DeletePipeline(e *Event) error {
 	url := fmt.Sprintf(
-		"%s/namespaces/%s/buildconfigs/%s?propagationPolicy=Background",
+		"%s/namespaces/%s/buildconfigs/%s?propagationPolicy=Foreground",
 		c.OpenShiftAPIBaseURL,
 		e.Namespace,
 		e.Pipeline,


### PR DESCRIPTION
https://github.com/openshift/origin/issues/14120 indicates that using
Foreground is a better option than Background, and there were cases in
which the builds where not cleaned up properly so far. We really do not
want this to happen.