### PR TITLE
Copy files in init.groovy.d during boot from image to volume

### DIFF
--- a/jenkins/master/Dockerfile
+++ b/jenkins/master/Dockerfile
@@ -5,4 +5,6 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt &
     rm -r /opt/openshift/configuration/jobs/OpenShift* && \
     touch /var/lib/jenkins/configured
 COPY configuration/ /opt/openshift/configuration/
+COPY ods-run /usr/libexec/s2i/ods-run
 ENV JENKINS_JAVA_OVERRIDES="-Dhudson.tasks.MailSender.SEND_TO_UNKNOWN_USERS=true -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true"
+CMD ["/usr/libexec/s2i/ods-run"]

--- a/jenkins/master/ods-run
+++ b/jenkins/master/ods-run
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# This script copies any init.groovy.d files under the control of OpenDevStack,
+# then delegates to the original run script of the base image.
+
+echo "Booting Jenkins ..."
+
+echo "Copy init.groovy.d files ..."
+source_init_groovy_dir="/opt/openshift/configuration/init.groovy.d"
+target_init_groovy_dir="${JENKINS_HOME}/init.groovy.d"
+for f in ${source_init_groovy_dir}/*.groovy; do
+    fileName=${f#${source_init_groovy_dir}'/'}
+    echo "---> Copying ${source_init_groovy_dir}/${fileName} to ${target_init_groovy_dir}/${fileName} ..."
+    cp "${source_init_groovy_dir}/${fileName}" "${target_init_groovy_dir}/${fileName}"
+done
+
+/usr/libexec/s2i/run


### PR DESCRIPTION
This ensures that those files are always present and up-todate.
Otherwise it is very hard to ship updates for those.

This has the downside that potential changes are overwritten. If you
need to keep your changes, you need to build a custom image / run
script.

Fixes #97.