### PR TITLE
webhook proxy doc update from README

### DIFF
--- a/docs/modules/jenkins/pages/webhook-proxy.adoc
+++ b/docs/modules/jenkins/pages/webhook-proxy.adoc
@@ -38,7 +38,7 @@ The following environment variables are read by the proxy:
 | Variable | Description
 
 | PROTECTED_BRANCHES
-| Comma-separated list of branches which pipelines should not be cleaned up. Use either exact branch names, branch prefixes (e.g. `feature/`) or `*` for all branches. Defaults to: `master,develop,production,staging,release/`
+| Comma-separated list of branches which pipelines should not be cleaned up. Use either exact branch names, branch prefixes (e.g. `feature/`) or `*` for all branches. Defaults to: `master,develop,production,staging,release/`.
 
 | OPENSHIFT_API_HOST
 | Defaults to `openshift.default.svc.cluster.local`. Usually does not need to be modified.
@@ -49,6 +49,11 @@ The following environment variables are read by the proxy:
 | TRIGGER_SECRET
 | The secret which protects the pipeline to be executed from outside. This variable is set by the template and usually does not need to be modified.
 |===
+
+Moreover, one can pass the following query parameters to the proxy:
+| Variable | Description |
+| -- | -- |
+| jenkinsfile_path | The path to the `Jenkinsfile`. By default, the `Jenkinsfile` is assumed to be in the root of the repository, therefore this value defaults to simply `Jenkinsfile`. |
 
 == Development
 


### PR DESCRIPTION
we have now the antora documentation integrated. 
Webhook proxy documentation is located here (generated from README)