### PR TITLE
added option to grab multiple hosts for trusted CA

### DIFF
--- a/jenkins/master/Dockerfile
+++ b/jenkins/master/Dockerfile
@@ -1,4 +1,16 @@
-FROM registry.access.redhat.com/openshift3/jenkins-2-rhel7
+FROM openshift/jenkins-2-centos7
+
+ENV JAVA_HOME /usr/lib/jvm/jre
+ARG APP_DNS=192.168.99.100.nip.io
+
+USER root
+RUN yum -y install openssl gnutls-utils && \
+    $JAVA_HOME/bin/keytool -storepasswd -new mysecretpassword -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit 
+
+# fetch certificates and store them in tmp directory
+COPY ./import_certs.sh /usr/local/bin/import_certs.sh
+RUN import_certs.sh
+
 COPY plugins.txt /opt/openshift/configuration/plugins.txt
 COPY kube-slave-common.sh /usr/local/bin/kube-slave-common.sh
 RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt && \
@@ -7,5 +19,7 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt &
 COPY configuration/ /opt/openshift/configuration/
 COPY openshift-sync.jar /opt/openshift/
 COPY ods-run /usr/libexec/s2i/ods-run
+
+USER jenkins
 ENV JENKINS_JAVA_OVERRIDES="-Dhudson.tasks.MailSender.SEND_TO_UNKNOWN_USERS=true -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true"
 CMD ["/usr/libexec/s2i/ods-run"]

--- a/jenkins/master/import_certs.sh
+++ b/jenkins/master/import_certs.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+oldIFS=$IFS
+IFS=';'
+KEYSTORE="$JAVA_HOME/lib/security/cacerts"
+
+if [ "${TARGET_HOSTS}x" == "x" ] ; then
+    TARGET_HOSTS=${APP_DNS}
+fi
+
+echo "KEYSTORE=${KEYSTORE}"
+for dns in $TARGET_HOSTS; do
+    cert_bundle_path="/etc/pki/ca-trust/source/anchors/${dns}.pem"
+    gnutls-cli --insecure --print-cert ${dns} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee ${cert_bundle_path}    
+    $JAVA_HOME/bin/keytool -import -noprompt -trustcacerts -file ${cert_bundle_path} -alias ${dns} -keystore ${KEYSTORE} -storepass changeit || true
+done
+update-ca-trust
+IFS=$oldIFS
+
+

--- a/jenkins/ocp-config/bc.yml
+++ b/jenkins/ocp-config/bc.yml
@@ -28,6 +28,11 @@ objects:
     strategy:
       type: Docker
       dockerStrategy:
+        env:
+          - name: APP_DNS
+            value: ${APP_DNS}
+          - name: TARGET_HOSTS
+            value: ${TARGET_HOSTS}
         from:
           kind: ImageStreamTag
           name: jenkins:2
@@ -67,6 +72,8 @@ objects:
             value: ${APP_DNS}
           - name: SNYK_DISTRIBUTION_URL
             value: ${SNYK_DISTRIBUTION_URL}
+          - name: TARGET_HOSTS
+            value: ${TARGET_HOSTS}
         from:
           kind: DockerImage
           name: ${JENKINS_SLAVE_BASE_FROM_IMAGE}
@@ -113,3 +120,5 @@ parameters:
   description: OpenShift application base dns - used for grabbing the root ca and adding into the slave
 - name: SNYK_DISTRIBUTION_URL
   description: optional uri that points to the snyk binary distribution (i.e. https://github.com/snyk/snyk/releases/download/v1.180.1/snyk-linux)
+- name: TARGET_HOSTS
+  description: if you have multiple DNS with different root ca, add them here seperated by ';'. They are added to jenkins master


### PR DESCRIPTION
Uses the import_certs script, that lets you specify TARGET_HOSTS (DNS names) seperated by ';'.
If TARGET_HOSTS is not provided it will use APP_DNS.

fixes #167 