### PR TITLE
Tag images with ODS version

### DIFF
--- a/jenkins/ocp-config/bc.yml
+++ b/jenkins/ocp-config/bc.yml
@@ -40,7 +40,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: 'jenkins-master:latest'
+        name: 'jenkins-master:2'
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -52,7 +52,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: 'jenkins-slave-base:latest'
+        name: 'jenkins-slave-base:2'
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -89,7 +89,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: 'jenkins-webhook-proxy:latest'
+        name: 'jenkins-webhook-proxy:2'
     postCommit: {}
     resources: {}
     runPolicy: Serial


### PR DESCRIPTION
Instead of advancing `latest`, we will now tag with the ODS version
to provide a more stable experience.

The implication of this is that with an ODS update, not all users
will automatically get the new version. They need to opt-in.

Please also see the related issue #210.

Closes #211.

@rattermeyer @clemensutschig @metmajer As this is a bigger conceptual change, I will wait with merging until you all approve this PR.

Once approved, I will create a follow-up PR in ods-project-quickstarters that makes all slave images use the same tag, and all `Jenkinsfile`s point to the ODS version tag.