### PR TITLE
Add scripts previously located in ods-project-quickstarters

### DIFF
--- a/ocp-scripts/clone-project.sh
+++ b/ocp-scripts/clone-project.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+set -e
+# removing option -x to avoid disclosure of passwords/tokens
+
+usage() {
+    echo "usage: sh $0 -p <project id> -o <openshift host> -b <bitbucket host> -c <http basic auth credentials \
+for bitbucket host> -t <target env to clone to> -s <source env to clone from>";
+}
+
+while [[ "$#" > 0 ]]; do case $1 in
+  -o=*|--openshift-host=*) OPENSHIFT_HOST="${1#*=}";;
+  -o|--openshift-host) OPENSHIFT_HOST="$2"; shift;;
+
+  -b=*|--bitbucket-host=*) BITBUCKET_HOST="${1#*=}";;
+  -b|--bitbucket-host) BITBUCKET_HOST="$2"; shift;;
+
+  -c=*|--credentials=*) CREDENTIALS="${1#*=}";;
+  -c|--credentials) CREDENTIALS="$2"; shift;;
+
+  -p=*|--project-id=*) PROJECT_ID="${1#*=}";;
+  -p|--project-id) PROJECT_ID="$2"; shift;;
+
+  -s=*|--source-env=*) SOURCE_ENV="${1#*=}";;
+  -s|--source-env) SOURCE_ENV="$2"; shift;;
+
+  -t=*|--target-env=*) TARGET_ENV="${1#*=}";;
+  -t|--target-env) TARGET_ENV="$2"; shift;;
+
+  -d|--debug) DEBUG=true;;
+
+  -st|--skiptags) SKIP_TAGS=true;;
+
+  -gb=*|--git-branch=*) GIT_BRANCH="${1#*=}";;
+  -gb|--git-branch) GIT_BRANCH="$2"; shift;;
+
+  -st|--skip-tag) SKIP_TAGS="true"; shift;;
+
+  -gb=*|--git-branch=*) GIT_BRANCH="${1#*=}";;
+  -gb|--git-branch) GIT_BRANCH="$2"; shift;;
+
+  *) echo "Unknown parameter passed: $1"; usage; exit 1;;
+esac; shift; done
+
+if [[ -z "$PROJECT_ID" ]]; then
+    echo "[ERROR]: No project id set - required value"
+    usage
+    exit 1
+fi
+if [[ -z "$BITBUCKET_HOST" ]]; then
+    echo "[ERROR]: No BitBucket host set - required value"
+    usage
+    exit 1
+fi
+if [[ -z "$CREDENTIALS" ]]; then
+    echo "[ERROR]: No BitBucket credentials set - required value"
+    usage
+    exit 1
+fi
+if [[ -z "$TARGET_ENV" ]]; then
+    echo "[ERROR]: No target environment set - required value"
+    usage
+    exit 1
+fi
+if [[ -z "$SOURCE_ENV" ]]; then
+    echo "[ERROR]: No source environment set - required value"
+    usage
+    exit 1
+fi
+if [[ -z "$OPENSHIFT_HOST" ]]; then
+    echo "[ERROR]: No OpenShift host set - required value"
+    usage
+    exit 1
+fi
+
+if [[ -z "$GIT_BRANCH" ]]; then
+    echo "[DEBUG]: no target git branch set - defaulting to master"
+    GIT_BRANCH=master
+fi
+
+echo "Provided params: \
+- PROJECT_ID: $PROJECT_ID \
+- OPENSHIFT_HOST: $OPENSHIFT_HOST \
+- BITBUCKET_HOST: $BITBUCKET_HOST \
+- CREDENTIALS: ******** \
+- SOURCE_ENV: $SOURCE_ENV \
+- TARGET_ENV: $TARGET_ENV"
+
+SOURCE_PROJECT="$PROJECT_ID-$SOURCE_ENV"
+TARGET_PROJECT="$PROJECT_ID-$TARGET_ENV"
+
+echo "[INFO]: creating workplace: mkdir -p oc_migration_scripts/migration_config"
+mkdir -p oc_migration_scripts/migration_config
+cd oc_migration_scripts
+echo $(pwd)
+export_url="https://$BITBUCKET_HOST/projects/opendevstack/repos/ods-quickstarters/raw/ocp-scripts/export_project.sh?at=refs%2Fheads%2Fproduction"
+curl --fail -s --user $CREDENTIALS -G $export_url -d raw -o export.sh
+import_url="https://$BITBUCKET_HOST/projects/opendevstack/repos/ods-quickstarters/raw/ocp-scripts/import_project.sh?at=refs%2Fheads%2Fproduction"
+curl --fail -s --user $CREDENTIALS -G $import_url -d raw -o import.sh
+
+cd migration_config
+echo $(pwd)
+
+echo "Creating source file"
+echo "oc_env=$OPENSHIFT_HOST" > ocp_project_config_source
+echo "OD_OCP_CD_SA_SOURCE=$(oc whoami | sed  -e 's/system:serviceaccount://g')" >> ocp_project_config_source
+
+echo "Creating target file"
+echo "oc_env=$OPENSHIFT_HOST" > ocp_project_config_target
+echo "OD_OCP_CD_SA_TARGET=$(oc whoami | sed  -e 's/system:serviceaccount://g')" >> ocp_project_config_target
+
+cd ..
+echo $(pwd)
+
+git_url="https://${CREDENTIALS//@/%40}@$BITBUCKET_HOST/scm/$PROJECT_ID/$PROJECT_ID-occonfig-artifacts.git"
+
+if [[ -z "$DEBUG" ]]; then
+  verbose=""
+else
+  verbose="-v true"
+fi
+
+echo "[INFO]: export resources from $SOURCE_ENV"
+sh export.sh -p $PROJECT_ID -h $OPENSHIFT_HOST -e $SOURCE_ENV -g $git_url -gb $GIT_BRANCH -cpj $verbose
+echo "[INFO]: import resources into $TARGET_ENV"
+sh import.sh -h $OPENSHIFT_HOST -p $PROJECT_ID -e $SOURCE_ENV -g $git_url -gb $GIT_BRANCH -n $TARGET_PROJECT $verbose --apply true
+
+echo "[INFO]: cleanup workplace"
+cd ..
+rm -rf oc_migration_scripts
+
+if [[ ! -z "$SKIP_TAGS" ]]; then
+  echo "[INFO] Skipping imagestream tagging"
+  return
+fi
+
+echo "[INFO]: import image tags from $SOURCE_ENV"
+oc get is --no-headers -n $SOURCE_PROJECT | awk '{print $2}' | while read DOCKER_REPO; do
+  echo "[INFO]: importing latest image from ${DOCKER_REPO}"
+  image="${DOCKER_REPO}:latest"
+  oc tag ${SOURCE_PROJECT}/${image} ${image} -n $TARGET_PROJECT || true
+done

--- a/ocp-scripts/delete-projects.sh
+++ b/ocp-scripts/delete-projects.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# This script creates the 3 OCP projects we currently require for every
+# ODS project.
+
+# Use -gt 1 to consume two arguments per pass in the loop (e.g. each
+# argument has a corresponding value to go with it).
+# Use -gt 0 to consume one or more arguments per pass in the loop (e.g.
+# some arguments don't have a corresponding value to go with it such
+# as in the --default example).
+# note: if this is set to -gt 0 the /etc/hosts part is not recognized ( may be a bug )
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -p|--project)
+    PROJECT="$2"
+    shift # past argument
+    ;;
+    *)
+        echo "Unknown option: $1. Exiting in case you did not intend to invoke this script."
+        exit 1
+    ;;
+esac
+shift # past argument or value
+done
+
+if [ -z ${PROJECT+x} ]; then
+    echo "PROJECT is unset";
+    exit 1;
+else echo "PROJECT=${PROJECT}"; fi
+
+oc delete project ${PROJECT}-cd
+oc delete project ${PROJECT}-dev
+oc delete project ${PROJECT}-test
+

--- a/ocp-scripts/export_project.sh
+++ b/ocp-scripts/export_project.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+set -e
+# Not using -x (tracing) to avoid disclosure of passwords/tokens when
+# processing arguments.
+
+# this script exports project templates for OpenDevStack in OpenShift
+#
+## settings
+## functions
+
+save_pvc_json_config()
+{
+   cat << EOF > ${pvc_json_conf_output_path}
+        {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": "$pvc_name"
+            },
+            "spec": {
+                "accessModes": [
+                    "$pvc_access_mode"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "$pvc_size"
+                    }
+                }
+            }
+        }
+EOF
+}
+
+save_is_json_config ()
+{
+    cat << EOF > ${is_json_conf_output_path}
+		{
+			"kind": "List",
+			"apiVersion": "v1",
+			"metadata": {},
+			"items": [
+				{
+					"kind": "ImageStream",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "$isname",
+						"namespace": "$project-$env",
+						"labels": {
+							"app": "$project",
+							"component": "$isname",
+							"env": "$env",
+							"template": "component-template"
+						},
+						"annotations": {
+							"description": "Keeps track of changes in the application image"
+						}
+					},
+					"spec": {
+						"dockerImageRepository": "$isname"
+					}
+				}
+			]
+		}
+EOF
+}
+
+save_route_json_config ()
+{
+    cat << EOF > ${route_json_conf_output_path}
+		{
+			"kind": "List",
+			"apiVersion": "v1",
+			"metadata": {},
+			"items": [
+				{
+					"kind": "Route",
+					"apiVersion": "v1",
+					"metadata": {
+						"name": "$routename",
+						"namespace": "$namespace",
+						"labels": {
+							"app": "$app",
+							"component": "$routename",
+							"env": "$env",
+							"template": "component-route-template"
+						}
+					},
+					"spec": {
+					    "host": "$host",
+                        "path" : "$api_path",
+						"to": {
+							"kind": "Service",
+							"name": "$service",
+							"weight": 100
+						},
+						"tls": {
+							"termination": "$termination",
+							"insecureEdgeTerminationPolicy": "$policy"
+						},
+						"wildcardPolicy": "None"
+					}
+				}
+			]
+		}
+EOF
+}
+
+## main
+echo " -- started"
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -p|--project)
+    OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG="$2"
+    shift # past argument
+    ;;
+    -t|--ocp_token)
+    OD_OCP_SOURCE_TOKEN="$2"
+    shift # past argument
+    ;;
+ 	-h|--ocp_host)
+    OD_OCP_SOURCE_HOST="$2"
+    shift # past argument
+    ;;
+	-e|--env)
+    OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES="$2"
+    shift # past argument
+    ;;
+    -g|--git)
+    OD_GIT_URL="$2"
+    shift # past argument
+    ;;
+    -gb|--gitbranch)
+    OD_GIT_BRANCH="$2"
+    shift # past argument
+    ;;
+    -gt|--gittag)
+    OD_GIT_TAG="$2"
+    shift # past argument
+    ;;
+    --force)
+    FORCE_PROJECT="$2"
+    shift # past argument
+    ;;
+    -v|--verbose)
+    OD_VERBOSE="$2"
+    shift # past argument
+    ;;
+    *)
+    # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+# force = true take the project name! (and don't expect a standard structure)
+if [[ ${FORCE_PROJECT} == "true" ]]; then
+	echo ">>> force project name: "${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}
+	OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES=${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}
+elif [[ -z ${OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES} ]]; then
+    # fallback
+	echo ">>> no project envs set - setting cd_test_dev"
+	echo
+    OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES=cd_test_dev
+fi
+
+if [ -z "${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG+x}" -o -z "${OD_GIT_URL+x}" -o -z "${OD_OCP_SOURCE_HOST}" ]; then
+	echo "!!!! mandatory params are unset !!! ";
+	echo "-h|--ocp_host: ${OD_OCP_SOURCE_HOST}"
+	echo "-t|--ocp_token: ********"
+	echo "-p|--project: ${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}"
+	echo "-e|--env: ${OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES}"
+	echo "-g|--git: ${OD_GIT_URL}"
+	exit 1
+else
+	echo "USING .... "
+	echo "project: ${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}"
+	echo "namespaces: ${OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES}"
+	echo "git url: ${OD_GIT_URL}"
+fi
+
+project_name=$OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG
+local_git_repo_fld=${project_name}-occonfig-artifacts
+
+# Test if the login token is provided to execute the login or just use current session
+if [ -z "$OD_OCP_SOURCE_TOKEN" ]; then
+  echo "Skiping 'oc login'... using current oc '`oc whoami`' session"
+else
+  echo " -- login to OpenShift (${OD_OCP_SOURCE_HOST})"
+  oc login ${OD_OCP_SOURCE_HOST} --token=${OD_OCP_SOURCE_TOKEN} >& /dev/null
+  if [ $? -ne 0 ]; then
+      echo "ERROR: could not login into ${OD_OCP_SOURCE_HOST} with oc"
+      exit 1
+  fi
+fi
+
+# Enable tracing only after token would be disclosed
+if [[ $OD_VERBOSE != "" ]]; then
+  set -x
+fi
+
+# checkout git repo (standard naming)
+git_repo=$OD_GIT_URL
+if [[ $OD_GIT_URL == *".git"* ]]; then
+  echo "using overwrite git url"
+else
+  git_repo=$OD_GIT_URL/scm/${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}/${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}-occonfig-artifacts.git
+fi
+
+temp_dir=$( mktemp -d )
+cd $temp_dir
+echo " -- cloning git repo $git_repo into $temp_dir"
+echo
+git clone $git_repo
+echo
+if [ $? -ne 0 ]; then
+    # little housekeeping
+    rm -rf $temp_dir
+    # error
+    echo "ERROR: could not clone the git repo $git_repo"
+    exit 1
+fi
+# step inside clonned git repo
+basename=$(basename $git_repo)
+clonned_git_fld_name=${basename%.*}
+cd $clonned_git_fld_name
+if [ $? -ne 0 ]; then
+    echo "ERROR: could not find a folder $clonned_git_fld_name after cloning git repo."
+    exit 1
+fi
+# switch to another git branch?
+git_checkout_expression="git checkout "
+# branch set in config
+if [[ -z ${OD_GIT_BRANCH// } ]]; then
+    # no -> set to default master branch
+    OD_GIT_BRANCH=master
+else
+    # yes
+    git_checkout_expression="$git_checkout_expression -b ${OD_GIT_BRANCH}"
+fi
+# tag set?
+if [[ ! -z ${OD_GIT_TAG// } ]]; then
+    # yes
+    git_checkout_expression="$git_checkout_expression tags/${OD_GIT_TAG}"
+fi
+#
+echo " -- check out git for $git_checkout_expression"
+eval ${git_checkout_expression}
+echo
+
+# create config file with source API OCP hostname ...
+echo "export_source_host=${OD_OCP_SOURCE_HOST}" > ocp_config
+
+#
+# export templates
+echo " -- exporting metadata"
+for ocp_proj_namespace_suffix in $(echo $OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES | sed -e 's/_/ /g'); # ${OD_PROJ_OCP_NAMESPACE_SOURCE_SUFFIXES[@]};
+do
+
+	if [[ ${FORCE_PROJECT} == "true" ]]; then
+    	curr_ocp_namespace=${project_name}
+    	ocp_proj_namespace_suffix=${project_name}
+    else
+    	curr_ocp_namespace=${project_name}-${ocp_proj_namespace_suffix}
+    fi
+
+    oc project ${curr_ocp_namespace}
+
+    echo " >>>>>>>>>>> -- exporting ocp project namespace ${curr_ocp_namespace} from (${OD_OCP_SOURCE_HOST}) -- <<<<<<<<<<<<<<<<<"
+	echo
+    mkdir -p ${ocp_proj_namespace_suffix}
+
+	oc export -o yaml secret,sa --namespace $curr_ocp_namespace > ${ocp_proj_namespace_suffix}/project.yml
+	oc export -o yaml rolebindings --namespace $curr_ocp_namespace > ${ocp_proj_namespace_suffix}/rolebindings.yml
+
+	if [ ! -s ${ocp_proj_namespace_suffix}/project.yml ]; then
+		echo "!! Project export is empty - as errors occured above, hence aborting - do you have full rights on ${curr_ocp_namespace} ?"
+		exit 1
+	fi
+    mkdir -p ${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}
+#
+    echo "    exporting config maps  for $curr_ocp_namespace"
+    configmap_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/configmap.tsv
+    oc get configmap --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${configmap_file}
+#
+    echo "-- generating config map yaml configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/config
+    while IFS= read line
+    do
+        #echo "    $line"
+        cmap_config=($line)
+        cmap_name=${cmap_config[0]}
+		oc export -o yaml configmap ${cmap_name} > ${ocp_proj_namespace_suffix}/config/configmap_${cmap_name}.yml
+        echo "   created configurationmap in cmap_${cmap_name}.yml"
+    done <"${configmap_file}";
+#
+    echo "    exporting service accounts for $curr_ocp_namespace"
+    sa_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/serviceaccounts.tsv
+    oc get sa --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${sa_file}
+#
+    echo "-- generating service account yaml configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/sa
+    while IFS= read line
+    do
+        #echo "    $line"
+        sa_config=($line)
+        sa_name=${sa_config[0]}
+		oc export -o yaml sa ${sa_name} > ${ocp_proj_namespace_suffix}/sa/sa_${sa_name}.yml
+        echo "   created service account in sa_${sa_name}.yml"
+    done <"${sa_file}";
+#
+    echo "    exporting templates for $curr_ocp_namespace"
+    template_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/templates.tsv
+    oc get template --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${template_file}
+#
+    echo "-- generating template yaml configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/template
+    while IFS= read line
+    do
+        #echo "    $line"
+        template_config=($line)
+        template_name=${template_config[0]}
+		oc export -o yaml template ${template_name} > ${ocp_proj_namespace_suffix}/template/template_${template_name}.yml
+        echo "   created template in template_${template_name}.yml"
+    done <"${template_file}";
+#
+    echo "    exporting build configs for $curr_ocp_namespace"
+    build_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/buildconfigs.tsv
+    oc get bc --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${build_file}
+#
+    echo "-- generating build yaml configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/bc
+    while IFS= read line
+    do
+        #echo "    $line"
+        bc_config=($line)
+        bc_name=${bc_config[0]}
+		oc export -o yaml bc ${bc_name} > ${ocp_proj_namespace_suffix}/bc/bc_${bc_name}.yml
+        echo "   created bc configuration in bc_${bc_name}.yml"
+    done <"${build_file}";
+#
+    echo "    exporting deployment configs for $curr_ocp_namespace"
+    deploy_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/deployconfigs.tsv
+    oc get dc --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${deploy_file}
+#
+    echo "-- generating deployment yaml configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/dc
+    while IFS= read line
+    do
+        #echo "    $line"
+        dc_config=($line)
+        dc_name=${dc_config[0]}
+		oc export -o yaml dc ${dc_name} > ${ocp_proj_namespace_suffix}/dc/dc_${dc_name}.yml
+        echo "   created dc configuration in dc_${dc_name}.yml"
+    done <"${deploy_file}";
+#
+    echo "    exporting services for $curr_ocp_namespace"
+    service_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/service.tsv
+    oc get service --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${service_file}
+#
+    echo "-- generating service yaml configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/service
+    while IFS= read line
+    do
+        #echo "    $line"
+        svc_config=($line)
+        svc_name=${svc_config[0]}
+		oc export -o yaml svc ${svc_name} > ${ocp_proj_namespace_suffix}/service/svc_${svc_name}.yml
+        echo "   created svc configuration in svc_${svc_name}.yml"
+    done <"${service_file}";
+#
+    echo "    exporting persistent volume claims for $curr_ocp_namespace"
+    tsv_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/pvc.tsv
+    oc get pvc --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1,4,5 > ${tsv_file}
+#
+    echo "-- generating pvc json configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/pvc
+
+    while IFS= read line
+    do
+        #echo "    $line"
+        pvc_config=($line)
+        pvc_name=${pvc_config[0]}
+        #echo "pvc_name: $pvc_name"
+        pvc_size=${pvc_config[1]}
+        #echo "pvc_size: $pvc_size"
+        pvc_access_mode=$( echo ${pvc_config[2]} | sed -e 's/ROX/ReadOnlyMany/g' -e 's/RWX/ReadWriteMany/g' -e 's/RWO/ReadWriteOnce/g' )
+        #echo "pvc_access_mode: $pvc_access_mode"
+		pv_name=${curr_ocp_namespace}-${pvc_name}
+		# echo "PVolume name - ${pv_name}"
+        pvc_json_conf_output_path="${ocp_proj_namespace_suffix}/pvc/pvc_${pvc_name}.json"
+        save_pvc_json_config
+        echo "   created pvc configuration in $pvc_json_conf_output_path"
+    done <"$tsv_file";
+#
+    echo "    exporting imagestreams for $curr_ocp_namespace"
+    is_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/is.tsv
+    oc get is --export=true --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1 > ${is_file}
+#
+    echo "-- generating is json configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/imagestream
+
+    while IFS= read line
+    do
+        #echo "    $line"
+        is_config=($line)
+        isname=${is_config[0]}
+        project=${project_name}
+        env=${ocp_proj_namespace_suffix}
+        is_json_conf_output_path="${ocp_proj_namespace_suffix}/imagestream/is_${isname}.json"
+        save_is_json_config
+        echo "   created is configuration in $is_json_conf_output_path"
+    done <"$is_file";
+#
+    echo "    exporting routes for $curr_ocp_namespace"
+	route_file=${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/route.tsv
+	oc get route --no-headers |  sed 's/  */ /g' | cut -d ' ' -f1,2,3,4,5,6,7 >${route_file}
+#
+    echo "-- generating route json configs"
+	mkdir -p ${ocp_proj_namespace_suffix}/route
+
+    while IFS= read line
+    do
+        #echo "    $line"
+        route_config=($line)
+
+        routename=${route_config[0]}
+        namespace=${curr_ocp_namespace}
+		app=${project_name}
+        env=${ocp_proj_namespace_suffix}
+		host=${route_config[1]}
+
+        # The size of the array is 7 when we have the path
+        if [ "${#route_config[@]}" = "7" ]; then
+            termination=$( echo ${route_config[5]} | sed -e 's/edge/edge/g' | cut -d '/' -f1 )
+            api_path=${route_config[2]}
+            service=${route_config[3]}
+        else
+            termination=$( echo ${route_config[4]} | sed -e 's/edge/edge/g' | cut -d '/' -f1 )
+            service=${route_config[2]}
+		fi
+
+		if [[ "${route_config[4]}" == *"/"* ]]; then
+			policy=$( echo ${route_config[4]} | sed -e 's/edge/edge/g' | cut -d '/' -f2 )
+		else
+			policy=
+		fi
+        route_json_conf_output_path="${ocp_proj_namespace_suffix}/route/route_${routename}.json"
+        save_route_json_config
+        echo "   created route configuration in $route_json_conf_output_path"
+
+
+    done <"$route_file";
+
+	echo
+    echo " ... DONE exporting project ${curr_ocp_namespace}"
+	echo
+
+    temp_dir_with_updated_files=$( mktemp -d )
+    if [ "$OD_REPLACE_EXPORTED_DATA_ENABLED" = true ] ; then
+        cd $temp_dir_with_updated_files
+
+        # checkout git repo
+        git_repo=$OD_GIT_URL
+        temp_dir=$( mktemp -d )
+        cd $temp_dir
+        echo " -- cloning git repo $git_repo into $temp_dir"
+        echo
+        git clone $git_repo
+        # step inside clonned git repo
+        basename=$(basename $git_repo)
+        clonned_git_fld_name=${basename%.*}
+        cd $clonned_git_fld_name
+        # switch to another git branch?
+        git_checkout_expression="git checkout "
+        # branch set in config
+        if [[ -z ${OD_GIT_BRANCH// } ]]; then
+            # no -> set to default master branch
+            OD_GIT_BRANCH=master
+        else
+            # yes
+            git_checkout_expression="$git_checkout_expression -b ${OD_GIT_BRANCH}"
+        fi
+        # tag set?
+        if [[ !  -z ${OD_GIT_TAG// } ]]; then
+            # yes
+            git_checkout_expression="$git_checkout_expression tags/${OD_GIT_TAG}"
+        fi
+        #
+        echo " -- check out git for $git_checkout_expression"
+        #git checkout -b ${OD_GIT_BRANCH} tags/${OD_GIT_TAG}
+        eval ${git_checkout_expression}
+        echo
+        #
+        echo " -- replacing data "
+        for yaml_file in ls ${temp_dir}/${clonned_git_fld_name}/${ocp_proj_namespace_suffix}/*.{yml,json}
+        do
+            if [[ -f $yaml_file ]]; then
+                cd ${ocp_proj_namespace_suffix}
+                yaml_filename=$(basename "$yaml_file")
+                output_yaml=${PWD}/${yaml_filename}
+                filename_without_extension="${yaml_filename%.*}"
+                output_diff=${PWD}/${filename_without_extension}.diff
+                echo "    transforming $yaml_file -> $output_yaml"
+                cat $yaml_file | sed -e "s/${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}-${ocp_proj_namespace_suffix}/${OD_OCP_PROJECT_NAMESPACE_PREFIX_NEW}-${ocp_proj_namespace_suffix}/g" \
+                -e "s/${OD_OCP_APP_SOURCE_DOMAIN}/${OD_OCP_APP_TARGET_DOMAIN}/g" > ${output_yaml}
+                diff_column_width=260 # because default 130 is too small for yml configs
+                diff $yaml_file ${output_yaml}  --side-by-side  --left-column -W 260 > ${output_diff}
+                cd ..
+            fi
+        done
+        temp_dir="$temp_dir_with_updated_files"
+    fi
+done
+cd ${temp_dir}/${clonned_git_fld_name} >& /dev/null
+#
+echo " -- pushing to remote git repo"
+
+git config --local user.email "undefined"
+git config --local user.name "CD System"
+
+git add --all >& /dev/null
+commit_msg="Automatic export from ${OD_OCP_SOURCE_HOST}"
+
+# allowed to fail
+set +e
+
+git commit -m "$commit_msg" -q
+#git remote add origin $OD_GIT_URL
+git push --set-upstream origin $OD_GIT_BRANCH
+cd - >& /dev/null
+echo " -- little housekeeping"
+rm -rf $temp_dir
+rm -rf $temp_dir_with_updated_files
+echo " -- finished"
+#END

--- a/ocp-scripts/import_project.sh
+++ b/ocp-scripts/import_project.sh
@@ -1,0 +1,788 @@
+#!/bin/bash
+set -e
+# Not using -x (tracing) to avoid disclosure of passwords/tokens when
+# processing arguments.
+
+# this script imports OCP project from metadata file located in a specified Git repo (input)
+# for OpenDevStack in OpenShift
+#
+## settings
+#
+
+eval_oc_artifact_status()
+{
+	local oc_command="oc "
+
+	#remove json and yml file suffixes
+	artifact_name=$(basename $artifact_file .yml)
+	artifact_name=$(basename $artifact_name .json)
+
+	#extract type from filename <type>_<filename>
+	artifact_type=$(basename $artifact_name | cut -d '_' -f1)
+	#remove artifact prefix
+	artifact_name=$(echo "${artifact_name}" | sed -e "s/${artifact_type}_//g")
+
+	# react to fail
+	set +e
+	oc get $artifact_type $artifact_name >& /dev/null
+	if [ $? -ne 0 ]; then
+		oc_command="$oc_command create -f "
+	else
+		# skip replace set? ...
+		if [[ ${skip_replace} == "true" || ${OD_USE_ADDONLY} == "true" ]]; then
+			oc_command="echo !!! NOT replacing $artifact_name with "
+		else
+			oc_command="$oc_command replace -f "
+		fi
+	fi
+	set -e
+	#the reason to only return the command here - is that we may use a tmp file later
+	#with replaced content
+	echo "$oc_command"
+}
+
+eval_oc_artifact_name()
+{
+	local oc_artifact=""
+
+	#remove json and yml file suffixes
+	artifact_name=$(basename $artifact_file .yml)
+	artifact_name=$(basename $artifact_name .json)
+
+	#extract type from filename <type>_<filename>
+	artifact_type=$(basename $artifact_name | cut -d '_' -f1)
+	#remove artifact prefix
+	artifact_name=$(echo "${artifact_name}" | sed -e "s/${artifact_type}_//g")
+
+	oc_artifact="$artifact_name"
+
+	echo "$oc_artifact"
+}
+#
+echo " -- started"
+## main
+
+while [[ $# -gt 1 ]]
+do
+key="$1"
+
+case $key in
+    -p|--project)
+    OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG="$2"
+    shift # past argument
+    ;;
+	-h|--ocp_host)
+    OD_OCP_TARGET_HOST="$2"
+    shift # past argument
+    ;;
+    -t|--ocp_token)
+    OD_OCP_TARGET_TOKEN="$2"
+    shift # past argument
+    ;;
+    -tr|--ocp_token_registry)
+    OD_OCP_SOURCE_TOKEN="$2"
+    shift # past argument
+    ;;
+    -e|--env)
+    OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES="$2"
+    shift # past argument
+    ;;
+    -g|--git)
+    OD_GIT_URL="$2"
+    shift # past argument
+    ;;
+    -gb|--gitbranch)
+    OD_GIT_BRANCH="$2"
+    shift # past argument
+    ;;
+    -gt|--gittag)
+    OD_GIT_TAG="$2"
+    shift # past argument
+    ;;
+	-a|--project_admins)
+    OD_PRJ_ADMINS="$2"
+    shift # past argument
+    ;;
+	-n|--target_project)
+    OD_TO_PROJECT="$2"
+    shift # past argument
+    ;;
+    --apply)
+    OD_USE_APPLY="$2"
+    shift # past argument
+    ;;
+    --addonly)
+    OD_USE_ADDONLY="$2"
+    shift # past argument
+    ;;
+    --force)
+    FORCE_PROJECT="$2"
+    shift # past argument
+    ;;
+    -v|--verbose)
+    OD_VERBOSE="$2"
+    shift # past argument
+    ;;
+    --skip-config-validation)
+    SKIP_CONF_VALIDATION="$2"
+    shift # past argument
+    ;;
+    *)
+    # unknown option
+    ;;
+esac
+shift # past argument or value
+done
+
+if [[ -z ${OD_PRJ_ADMINS} ]]; then
+    # fallback
+	echo ">>> no project admins set - setting clemens :)"
+	echo
+    OD_PRJ_ADMINS=utschig
+else
+	# prepend clemens' account
+    OD_PRJ_ADMINS=utschig,${OD_PRJ_ADMINS}
+fi
+
+if [[ -z ${OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES} ]]; then
+    # fallback
+	echo ">>> no project envs set - setting cd_test_dev"
+	echo
+    OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES=cd_test_dev
+fi
+
+if [ -z "${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG+x}" -o -z "${OD_GIT_URL+x}" -o -z "${OD_OCP_TARGET_HOST}" ]; then
+	echo "!!!! mandatory params are unset !!! ";
+	echo "-h|--ocp_host: ${OD_OCP_TARGET_HOST}"
+	echo "-t|--ocp_token: ********"
+	echo "-p|--project: ${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}"
+	echo "-e|--env: ${OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES}"
+	echo "-g|--git: ${OD_GIT_URL}"
+	echo "-n|--target_project: ${OD_TO_PROJECT}"
+
+	exit 1
+else
+	echo "USING .... "
+	echo "project: ${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}"
+	echo "git url: ${OD_GIT_URL}"
+	echo "git branch / tag: ${OD_GIT_BRANCH} / ${OD_GIT_TAG}"
+	echo "namespaces: ${OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES}"
+	echo "admins : ${OD_PRJ_ADMINS}"
+	echo "new project name : ${OD_TO_PROJECT}"
+	if [[ ${OD_USE_ADDONLY} == "true" ]]; then
+		echo "-- adding missing artifacts only"
+	fi
+	echo ""
+fi
+
+# Enable debug mode
+if [[ $OD_VERBOSE != "" ]]; then
+  set -x
+fi
+
+# grab for later - to source configuration
+scriptdir=$(pwd)
+
+# find the right configuration to use based on the target API host passed parameter
+targetconfig=$(grep -H $OD_OCP_TARGET_HOST $scriptdir/migration_config/ocp_project_config_target* | cut -d ':' -f1)
+
+if [[ -f "$targetconfig" ]]; then
+	echo "> sourcing env target config from $targetconfig"
+	source $targetconfig
+else
+	echo "Target cluster config $targetconfig, for cluster $OD_OCP_TARGET_HOST could NOT be located - this is a must to successfully run this script"
+	exit 1
+fi
+
+if [[ -z ${OD_EXCLUDE_NAMESPACES} ]]; then
+    # fallback
+	echo ">>> no namespace exclusions set - cd / shared-images / openshift and rhscl"
+	echo
+    OD_EXCLUDE_NAMESPACES=cd,shared-images,openshift,rhscl
+fi
+
+# checkout git repo (standard naming)
+git_repo=$OD_GIT_URL
+if [[ $OD_GIT_URL == *".git"* ]]; then
+  echo "using overwrite git url"
+else
+  git_repo=$OD_GIT_URL/scm/${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}/${OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG}-occonfig-artifacts.git
+fi
+
+temp_dir=$( mktemp -d )
+cd $temp_dir
+echo " -- cloning git repo $git_repo into $temp_dir"
+echo
+git clone $git_repo
+echo
+if [ $? -ne 0 ]; then
+    # little housekeeping
+    rm -rf $temp_dir
+    # error
+    echo "ERROR: could not clone the git repo $git_repo"
+    exit 1
+fi
+# step inside clonned git repo
+basename=$(basename $git_repo)
+clonned_git_fld_name=${basename%.*}
+cd $clonned_git_fld_name
+if [ $? -ne 0 ]; then
+    echo "ERROR: could not find a folder $clonned_git_fld_name after cloning git repo."
+    exit 1
+fi
+# switch to another git branch?
+git_checkout_expression="git checkout "
+# branch set in config
+if [[ -z ${OD_GIT_BRANCH// } ]]; then
+    # no -> set to default master branch
+    git_checkout_expression="$git_checkout_expression"
+else
+    # yes
+    git_checkout_expression="$git_checkout_expression ${OD_GIT_BRANCH}"
+fi
+# tag set?
+if [[ !  -z ${OD_GIT_TAG// } ]]; then
+    # yes
+    git_checkout_expression="$git_checkout_expression tags/${OD_GIT_TAG}"
+fi
+#
+echo " -- check out git for $git_checkout_expression"
+
+eval ${git_checkout_expression}
+echo
+#
+echo
+if [ $? -ne 0 ]; then
+    echo "ERROR: could not clone the git repo $git_repo - trying with a hot clone"
+	# little housekeeping
+	rm -rf $temp_dir
+fi
+
+# find the right configuration based on the API host source config
+if [[ -f "ocp_config" ]]; then
+	sourceHost=$(grep export ocp_config | cut -d '=' -f2)
+	sourceconfig=$(grep -H $sourceHost $scriptdir/migration_config/ocp_project_config_source | cut -d ':' -f1)
+
+	echo "sourcehost : $sourceHost sourceconfig : $sourceconfig"
+
+	if [[ -f "$sourceconfig" ]]; then
+		echo "> sourcing env source config from $sourceconfig"
+		source $sourceconfig
+	else
+		echo "Cannot find $sourceconfig aborting"
+		exit  1
+	fi
+else
+	echo "ERROR: no config directory was found"
+	exit 1
+fi
+
+OD_PRJ_ADMINS=$OD_PRJ_ADMINS,$OD_OCP_CD_SA_TARGET
+
+if [[ ! "$SKIP_CONF_VALIDATION" = "true" ]]; then
+    if grep -q $OD_OCP_TARGET_HOST $sourceconfig; then
+        echo "Source and Target cluster are the same. Validating configuration..."
+
+
+        if [[ ! -z "$OD_OCP_SOURCE_APP_DOMAIN" ]]; then
+            if [[ -z "$OD_OCP_TARGET_APP_DOMAIN" ]]; then
+                echo "Target domain is empty while source is not. It should be to prevent errors"
+                exit 1
+            fi
+        fi
+
+        if [[ ! -z "$OD_OCP_SOURCE_NEXUS_URL" ]]; then
+            if [[ -z "$OD_OCP_TARGET_NEXUS_URL" ]]; then
+                echo "Target nexus url is empty while source is not. It should be to prevent errors"
+                exit 1
+            fi
+        fi
+
+        if [[ ! -z "$OD_OCP_SOURCE_SQ_URL" ]]; then
+            if [[ -z "$OD_OCP_TARGET_SQ_URL" ]]; then
+                echo "Target Sonarqube url is empty while source is not. It should be to prevent errors"
+                exit 1
+            fi
+        fi
+
+        if [[ ! -z "$OD_OCP_SOURCE_BITBUCKET_URL" ]]; then
+            if [[ -z "$OD_OCP_TARGET_BITBUCKET_URL" ]]; then
+                echo "Target bitbucket url is empty while source is not. It should be to prevent errors"
+                exit 1
+            fi
+        fi
+
+        if [[ ! -z "$OD_OCP_CD_SA_SOURCE" ]]; then
+            if [[ -z "$OD_OCP_CD_SA_TARGET" ]]; then
+                echo "Target service account is empty while source is not. It should be to prevent errors"
+                exit 1
+            fi
+        fi
+
+    else
+        echo "Source and Target cluster are NOT the same. Validating configuration..."
+
+        if [[ -z "$OD_OCP_SOURCE_APP_DOMAIN" ]]; then
+            echo "Source domain is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ -z "$OD_OCP_TARGET_APP_DOMAIN" ]]; then
+            echo "Target domain is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ "$OD_OCP_SOURCE_APP_DOMAIN" = "$OD_OCP_TARGET_APP_DOMAIN" ]]; then
+            echo "Source and Target domains are the same. It should be different when importing into a different cluster"
+            exit 1
+        fi
+
+
+        if [[ -z "$OD_OCP_SOURCE_NEXUS_URL" ]]; then
+            echo "Source nexus url is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ -z "$OD_OCP_TARGET_NEXUS_URL" ]]; then
+            echo "Target nexus url is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ "$OD_OCP_SOURCE_NEXUS_URL" = "$OD_OCP_TARGET_NEXUS_URL" ]]; then
+            echo "Source and Target nexus urls are the same. It should be different when importing into a different cluster"
+            exit 1
+        fi
+
+
+        if [[ -z "$OD_OCP_SOURCE_SQ_URL" ]]; then
+            echo "Source Sonarqube url is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ -z "$OD_OCP_TARGET_SQ_URL" ]]; then
+            echo "Target Sonarqube url is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ "$OD_OCP_SOURCE_SQ_URL" = "$OD_OCP_TARGET_SQ_URL" ]]; then
+            echo "Source and Target Sonarqube urls are the same. It should be different when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ -z "$OD_OCP_SOURCE_BITBUCKET_URL" ]]; then
+            echo "Source bitbucket url is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ -z "$OD_OCP_TARGET_BITBUCKET_URL" ]]; then
+            echo "Target bitbucket url is empty. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ "$OD_OCP_SOURCE_BITBUCKET_URL" = "$OD_OCP_TARGET_BITBUCKET_URL" ]]; then
+            echo "Source and Target bitbuckets urls are the same. It should be different when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ -z "$OD_OCP_JENKINS_MASTER_IMAGE_SPACE_SOURCE" ]]; then
+            "Source space for Jenkins image is not set. It should be set when importing into a different cluster"
+            exit 1
+        fi
+
+        if [[ ! -z "$OD_OCP_CD_SA_SOURCE" ]]; then
+            if [[ -z "$OD_OCP_CD_SA_TARGET" ]]; then
+                echo "Target service account is empty while source is not. It should be to prevent errors"
+                exit 1
+            fi
+        fi
+    fi
+else
+    echo "WARNING!!! Validation was skipped"
+fi
+
+
+
+# Test if the login token is provided to execute the login or just use current session
+if [ -z "$OD_OCP_TARGET_TOKEN" ]; then
+  echo "Skiping 'oc login'... using current oc '`oc whoami`' session"
+else
+  echo " -- login to OpenShift (${OD_OCP_TARGET_HOST})"
+  oc login ${OD_OCP_TARGET_HOST} --token=${OD_OCP_TARGET_TOKEN} >& /dev/null
+  if [ $? -ne 0 ]; then
+      echo "ERROR: could not login into ${OD_OCP_TARGET_HOST} with oc"
+      exit 1
+  fi
+fi
+
+# setup 3 OpenShift projects
+# HINT: folder name should look like <project_name>-occonfig-artifacts
+project_name=$( echo $clonned_git_fld_name | cut -d '-' -f1 )
+#
+if [ -z $project_name ] && [[ ! ${FORCE_PROJECT} == "true" ]]; then
+    echo "ERROR: could not extract project_name from a folder name $clonned_git_fld_name"
+    exit 1
+fi
+
+# static variables and replacements - source to target
+tmp_postfix=.tmp
+
+#
+for ocp_proj_namespace_suffix in $(echo $OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES | sed -e 's/_/ /g');
+do
+	if [[ ${FORCE_PROJECT} == "true" ]]; then
+    	curr_ocp_namespace=${ocp_proj_namespace_suffix}
+    else
+    	curr_ocp_namespace=${project_name}-${ocp_proj_namespace_suffix}
+    fi
+
+    cd $ocp_proj_namespace_suffix
+    echo "current source folder: ${PWD}"
+
+	if [[ ! -z ${OD_TO_PROJECT} ]]; then
+		curr_ocp_namespace=${OD_TO_PROJECT}
+		echo " ----> cloning ${project_name}-${ocp_proj_namespace_suffix} into ${curr_ocp_namespace}"
+	else
+	    echo " -- creating new project ${curr_ocp_namespace} in OpenShift (${OD_OCP_TARGET_HOST})"
+	fi
+
+	# react to fail
+	set +e
+	oc project ${curr_ocp_namespace} >& /dev/null
+	result=$?
+	set -e
+
+	# assumption : if the project is there - it was created via opendevstack ...
+    if [ $result -ne 0 ]; then
+        echo "Could not find project ${curr_ocp_namespace} - creating"
+
+		if [ ! -s project.yml ]; then
+			echo "!! Project export is empty - as errors occured above, hence aborting"
+			exit 1
+		fi
+
+		oc new-project ${curr_ocp_namespace} || exit 1
+		# create the baseline with service accounts, role bindings - and switch SA account
+		cp project.yml project.yml$tmp_postfix
+		cp rolebindings.yml rolebindings.yml$tmp_postfix
+		if [[ ! -z "$OD_OCP_CD_SA_SOURCE" ]]; then
+		    sed -i -e "s|$OD_OCP_CD_SA_SOURCE|$OD_OCP_CD_SA_TARGET|g" project.yml$tmp_postfix
+		    sed -i -e "s|$OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG-$OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES|$curr_ocp_namespace|g" project.yml$tmp_postfix
+
+		    sed -i -e "s|$OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG-$OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES|$curr_ocp_namespace|g" rolebindings.yml$tmp_postfix
+		else
+			echo "OD_OCP_CD_SA_SOURCE is empty! can't continue..."
+			exit 1
+		fi
+
+		# removing fail on error due to trying to promote cluster deployer role:
+		# Error from server (Forbidden): rolebindings.authorization.openshift.io "system:deployers" is forbidden: attempt to grant extra privileges
+		set +e
+		if [ "$OD_USE_APPLY" = true ]; then
+			# https://access.redhat.com/solutions/4272322
+			oc apply -f project.yml$tmp_postfix
+		else
+			oc create --save-config -f project.yml$tmp_postfix
+		fi
+		oc create --save-config -f rolebindings.yml$tmp_postfix -n ${curr_ocp_namespace} || true
+		set -e
+
+		if [[ $ocp_proj_namespace_suffix == "cd" ]]; then
+			oc create sa jenkins -n ${project_name}-${ocp_proj_namespace_suffix}
+		fi
+
+		# admin for the creating SA and image pull rights
+		oc policy add-role-to-user admin system:serviceaccount:${OD_OCP_CD_SA_TARGET}
+		oc policy add-role-to-user system:image-puller system:serviceaccount:${OD_OCP_CD_SA_TARGET}
+		# everyone authenticated can see
+		oc policy add-role-to-group view system:authenticated
+		# image-builder for sa default needed to import images from other cluster
+		oc policy add-role-to-user system:image-builder -z default -n ${project_name}-${ocp_proj_namespace_suffix}
+
+		# if jenkins CD is NOT part of the import it does not make sense to try to create the linking SA
+		if [[ $OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES == *"cd"* ]];
+		then
+			echo "creating service account jenkins to modify build configs during jenkins build"
+			oc policy add-role-to-user admin system:serviceaccount:${project_name}-cd:jenkins -n ${project_name}-${ocp_proj_namespace_suffix}
+			echo
+		fi
+
+		# add pull rights against ocp OD dedicated - for NON CD projects - otherwise we even pull the jenkins image and that we dont want
+		if [[ $ocp_proj_namespace_suffix == "cd" ]]; then
+			echo "--  not creating pull secret to OCP, this is CD - just adding image pull rights"
+			oc policy add-role-to-user system:image-puller system:serviceaccount:${project_name}-cd:jenkins -n cd
+		fi
+
+	else
+		echo "!!! Project ${curr_ocp_namespace} already exists - skipping creation"
+    fi
+
+	SAVED_OPTIONS=$-
+	set +x  # switch off tracing to not disclose secrets or token
+
+	# allow it to fail
+	set +e
+	secretkey=odocp
+	secretexists=$(oc get secret | grep "$secretkey")
+	set -e
+
+	if [[ ! -z ${OD_OCP_SOURCE_TOKEN} ]] && [[ ! "$ocp_proj_namespace_suffix" == "cd" ]] && [[ ! $secretexists == *"$secretkey"* ]]; then
+		echo "Creating OCP OD pull secret for ${OD_OCP_DOCKER_REGISTRY_SOURCE_HOST}"
+		oc create secret docker-registry ${secretkey} --docker-server=${OD_OCP_DOCKER_REGISTRY_SOURCE_HOST} --docker-username=cd/cd-integration --docker-password=${OD_OCP_SOURCE_TOKEN} --docker-email=a@b.com
+		oc secrets link deployer ${secretkey} --for=pull
+		oc secrets link default ${secretkey} --for=pull
+	else
+		echo "OCP OD Token not set - assuming local build"
+	fi
+	set $SAVED_OPTIONS
+
+	# add admins
+	for admin_user in $(echo $OD_PRJ_ADMINS | sed -e 's/,/ /g');
+	do
+		oc policy add-role-to-user admin ${admin_user}
+	done
+
+	echo
+    echo "    importing persistent volume claims"
+    for pvc_config_json in ./pvc/pvc_*.json; do
+		if [ ! -f "$pvc_config_json" ]
+		then
+			echo "No artifacts fround that match $pvc_config_json"
+			break
+		fi
+
+		artifact_file=${pvc_config_json}
+		skip_replace=true
+
+		occomm=$(eval_oc_artifact_status)$pvc_config_json
+
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $pvc_config_json
+        echo
+    done
+
+	echo "    importing image streams"
+    for is_config_json in ./imagestream/is_*.json; do
+		if [ ! -f "$is_config_json" ]
+		then
+			echo "No artifacts fround that match $is_config_json"
+			break
+		fi
+
+		artifact_file=${is_config_json}
+		skip_replace=true
+
+		cat $is_config_json | sed -e "s|$project_name-$ocp_proj_namespace_suffix|$OD_TO_PROJECT|g" > $is_config_json$tmp_postfix
+
+		occomm=$(eval_oc_artifact_status)$is_config_json$tmp_postfix
+
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $is_config_json
+        echo
+    done
+
+	echo "    importing templates"
+    for template_config_json in ./template/template_*.yml; do
+		if [ ! -f "$template_config_json" ]
+		then
+			echo "No artifacts fround that match $template_config_json"
+			break
+		fi
+		artifact_file=${template_config_json}
+		skip_replace=false
+
+		# replace hosts
+		cp $template_config_json $template_config_json$tmp_postfix
+		if [[ ! -z "$OD_OCP_SOURCE_APP_DOMAIN" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_APP_DOMAIN|$OD_OCP_TARGET_APP_DOMAIN|g" $template_config_json$tmp_postfix
+		fi
+
+		if [[ ! -z "$OD_OCP_SOURCE_BITBUCKET_URL" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_BITBUCKET_URL|$OD_OCP_TARGET_BITBUCKET_URL|g"  $template_config_json$tmp_postfix
+		fi
+
+		occomm=$(eval_oc_artifact_status)$template_config_json$tmp_postfix
+
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $template_config_json
+        echo
+    done
+
+	echo "    importing config maps"
+    for cmap_config_json in ./config/configmap_*.yml; do
+		if [ ! -f "$cmap_config_json" ]
+		then
+			echo "No artifacts fround that match $cmap_config_json"
+			break
+		fi
+		artifact_file=${cmap_config_json}
+		skip_replace=false
+
+		# replace hosts
+
+		cp $cmap_config_json $cmap_config_json$tmp_postfix
+		if [[ ! -z "$OD_OCP_SOURCE_APP_DOMAIN" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_APP_DOMAIN|$OD_OCP_TARGET_APP_DOMAIN|g" $cmap_config_json$tmp_postfix
+		fi
+
+		if [[ ! -z "$OD_OCP_SOURCE_BITBUCKET_URL" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_BITBUCKET_URL|$OD_OCP_TARGET_BITBUCKET_URL|g"  $cmap_config_json$tmp_postfix
+		fi
+
+		occomm=$(eval_oc_artifact_status)$cmap_config_json$tmp_postfix
+
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $cmap_config_json
+        echo
+    done
+
+	echo "    importing deploy configs"
+	# replace nexus host and also an image ns reference to ODjenkins
+    for dc_config_json in ./dc/dc_*.yml; do
+		if [ ! -f "$dc_config_json" ]
+		then
+			echo "No artifacts fround that match $dc_config_json"
+			break
+		fi
+
+		cp  $dc_config_json $dc_config_json$tmp_postfix
+		if [[ ! -z "$OD_OCP_SOURCE_NEXUS_URL" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_NEXUS_URL|$OD_OCP_TARGET_NEXUS_URL|g"  $dc_config_json$tmp_postfix
+		fi
+
+		if [[ ! -z "$OD_OCP_SOURCE_SQ_URL" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_SQ_URL|$OD_OCP_TARGET_SQ_URL|g"  $dc_config_json$tmp_postfix
+		fi
+
+   		sed  -i -e "s|$project_name-$ocp_proj_namespace_suffix|$curr_ocp_namespace|g" $dc_config_json$tmp_postfix
+
+
+		if [[ ! -z "$OD_OCP_JENKINS_MASTER_IMAGE_SPACE_SOURCE" ]]; then
+		    sed  -i -e "s|namespace: $OD_OCP_JENKINS_MASTER_IMAGE_SPACE_SOURCE|namespace: $OD_OCP_SHARED_SPACE_TARGET|g" $dc_config_json$tmp_postfix
+		fi
+
+		if [[ ! -z "$OD_OCP_SHARED_SPACE_SOURCE" ]]; then
+		    sed  -i -e "s|$OD_OCP_SHARED_SPACE_SOURCE|$OD_OCP_SHARED_SPACE_TARGET|g" $dc_config_json$tmp_postfix
+		fi
+
+
+		artifact_file=${dc_config_json}
+		artifactName=$(eval_oc_artifact_name)
+
+		skip_replace=false
+		occomm=$(eval_oc_artifact_status)$dc_config_json$tmp_postfix
+
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $dc_config_json
+
+		# grab the stream data so we can import later
+		ref_imagestreamWithRegistry=$( cat $dc_config_json | grep image: | sed -e 's/ //g' | cut -d ':' -f2,3 | cut -d '@' -f1  | head -1)
+		ref_imagestreamOwningProject=$(echo $ref_imagestreamWithRegistry | cut -d '/' -f2)
+		ref_imagestreamName=$(echo $ref_imagestreamWithRegistry | cut -d '/' -f3)
+
+		echo " --> checking for referenced project image - stream: $ref_imagestreamWithRegistry"
+
+		exlude_this_namespace=false
+
+		# check for any exclusions
+		for exclude_namespace in $(echo $OD_EXCLUDE_NAMESPACES | sed -e 's/,/ /g');
+		do
+			if [[ $ref_imagestreamOwningProject == $exclude_namespace ]]; then
+				exlude_this_namespace=true
+				echo "... setting exclusion for image $ref_imagestreamWithRegistry based on $OD_EXCLUDE_NAMESPACES"
+			fi
+		done
+
+		# dont do any import on shared images from shared-image namespace and from CD
+		SAVED_OPTIONS=$-
+		set +x  # switch off tracing to not disclose secrets or token
+		if [ "$exlude_this_namespace" = false ] && [ ! -z ${OD_OCP_SOURCE_TOKEN// } ] && [[ ! "$ocp_proj_namespace_suffix" == "cd" ]]; then
+			echo "Importing remote images ${OD_OCP_DOCKER_REGISTRY_SOURCE_HOST}/${ref_imagestreamOwningProject}/${ref_imagestreamName} into ${ref_imagestreamName}"
+			oc import-image ${ref_imagestreamName} --from=${OD_OCP_DOCKER_REGISTRY_SOURCE_HOST}/${ref_imagestreamOwningProject}/${ref_imagestreamName} --confirm
+		else
+		    echo "Leaving referenced image $ref_imagestreamWithRegistry as is!"
+		fi
+		set $SAVED_OPTIONS
+        echo
+    done
+
+	echo "    importing services"
+    for svc_config_json in ./service/svc_*.yml; do
+		if [ ! -f "$svc_config_json" ]
+		then
+			echo "No artifacts fround that match $svc_config_json"
+			break
+		fi
+
+		artifact_file=${svc_config_json}
+		skip_replace=true
+
+		occomm=$(eval_oc_artifact_status)$svc_config_json
+
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $svc_config_json
+        echo
+    done
+
+	# for cd this has to be done AFTER the deployment config and services - as it pulls the image straight away and starts a deployment
+	# in case nothing else was created yet
+	echo "    importing build configs"
+    for bc_config_json in ./bc/bc_*.yml; do
+		if [ ! -f "$bc_config_json" ]
+		then
+			echo "No artifacts fround that match $bc_config_json"
+			break
+		fi
+
+		artifact_file=${bc_config_json}
+		skip_replace=false
+
+		cp $bc_config_json $bc_config_json$tmp_postfix
+		if [[ ! -z "$OD_OCP_SOURCE_APP_DOMAIN" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_APP_DOMAIN|$OD_OCP_TARGET_APP_DOMAIN|g" $bc_config_json$tmp_postfix
+		fi
+
+		if [[ ! -z "$OD_OCP_SOURCE_BITBUCKET_URL" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_BITBUCKET_URL|$OD_OCP_TARGET_BITBUCKET_URL|g"  $bc_config_json$tmp_postfix
+		fi
+
+
+		occomm=$(eval_oc_artifact_status)$bc_config_json$tmp_postfix
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $bc_config_json
+		echo
+	done
+
+	echo "    importing routes"
+    for route_config_json in ./route/route_*.json; do
+		if [ ! -f "$route_config_json" ]
+		then
+			echo "No artifacts fround that match $route_config_json"
+			break
+		fi
+
+		artifact_file=${route_config_json}
+		skip_replace=false
+
+		cp $route_config_json $route_config_json$tmp_postfix
+		if [[ ! -z "$OD_OCP_SOURCE_APP_DOMAIN" ]]; then
+		     sed -i -e "s|$OD_OCP_SOURCE_APP_DOMAIN|$OD_OCP_TARGET_APP_DOMAIN|g" $route_config_json$tmp_postfix
+		fi
+
+		if [ ! -z "$OD_TO_PROJECT" ]; then
+			sed -i -e "s|$OD_OCP_PROJECT_NAMESPACE_PREFIX_ORG-$OD_PROJ_OCP_NAMESPACE_TARGET_SUFFIXES|$OD_TO_PROJECT|g" $route_config_json$tmp_postfix
+		fi
+
+		occomm=$(eval_oc_artifact_status)$route_config_json$tmp_postfix
+		eval ${occomm}
+		git log -n 1 --format="commit: %H by: %aN on: %aD" -- $route_config_json
+        echo
+    done
+
+    cd ..
+done
+cd - >& /dev/null
+# little housekeeping in host OS
+echo " -- removing temp directory ${temp_dir}"
+rm -rf ${temp_dir}
+echo " -- finished"
+#END


### PR DESCRIPTION
Closes
https://github.com/opendevstack/ods-project-quickstarters/issues/1.

Just moving the scripts to a new location - I always thought these should be part of `ods-core` anyway.

I did not make any adjustments except some path changes in `clone-project.sh`.