### PR TITLE
Remove references to ods-project-quickstarters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ All the contained components except Atlassian tools are built in the Openshift c
 ## Contents
 1. [Jenkins master](jenkins/master) & base slave - the basis of the ODS build engine <br>
 The [base slave](jenkins/slave-base) provides plugins for OWASP, Sonarqube, and CNES and is HTTP proxy aware.
-Specific [quickstarters / boilerplates](https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates) require different technologies e.g. `gradle`, `NPM/Yarn` etc. to build, hence warrant their own `builder slaves`. These `slaves` are based on this `base slave` and are hosted in the [ods-project-quickstarter repository](https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves) - next to their respective [boilerplates](https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates). <br><br>During `jenkins` builds instances/pods of those `builder` images can be found within the project specific `project-cd` namespace.
+Specific [quickstarters / boilerplates](https://github.com/opendevstack/ods-quickstarters/tree/master) require different technologies e.g. `gradle`, `NPM/Yarn` etc. to build, hence warrant their own `builder slaves`. These `slaves` are based on this `base slave` and are hosted in the [ods-quickstarter repository](https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves) - next to their respective [boilerplates](https://github.com/opendevstack/ods-quickstarters/tree/master). <br><br>During `jenkins` builds instances/pods of those `builder` images can be found within the project specific `project-cd` namespace.
 
-2. [Nexus](nexus) - repository manager <br>
-Nexus is used as artifact manager throughout OpenDevStack. Each [`jenkins slave`](https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves) is configured to bind to the installed NEXUS to centralize build / dependency artifact resolution. There is one central instance of Nexus in the `CD` project
+1. [Nexus](nexus) - repository manager <br>
+Nexus is used as artifact manager throughout OpenDevStack. Each [`jenkins slave`](https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves) is configured to bind to the installed NEXUS to centralize build / dependency artifact resolution. There is one central instance of Nexus in the `CD` project
 
-3. [Sonarqube](sonarqube) - Sofware quality management <br>
-The OpenDevStack version of Sonarqube - preconfigured with language plugins used by the [`boilerplates`](https://github.com/opendevstack/ods-project-quickstarters/tree/master/boilerplates). All generated `jenkinsfiles` contain a stage `stageScanForSonarQube` for sourcecode review - which connects to this central instance. There is one central instance of SQ in the `CD` project
+1. [Sonarqube](sonarqube) - Sofware quality management <br>
+The OpenDevStack version of Sonarqube - preconfigured with language plugins used by the [boilerplates](https://github.com/opendevstack/ods-quickstarters/tree/master). All generated `Jenkinsfile`s contain a stage `stageScanForSonarQube` for sourcecode review - which connects to this central instance. There is one central instance of SQ in the `CD` project
 
 4. [Shared images](shared-images) - Docker Images for common functionality <br>
    1. The [Airflow](shared-images/airflow) and [Elasticsearch](shared-images/elasticsearch) images - used for Airflow quickstarter, an [Airflow](https://airflow.apache.org/) OpenDevStack compatible and enhanced implementation.

--- a/docs/modules/ROOT/pages/getting-started.adoc
+++ b/docs/modules/ROOT/pages/getting-started.adoc
@@ -492,9 +492,8 @@ You will have to create the repositories listed in the table below.
 
 | ods-core
 | ods-configuration
-| ods-configuration-sample
 | ods-jenkins-shared-library
-| ods-project-quickstarters
+| ods-quickstarters
 | ods-provisioning-app
 |===
 

--- a/docs/modules/jenkins/pages/slave-base.adoc
+++ b/docs/modules/jenkins/pages/slave-base.adoc
@@ -2,7 +2,7 @@
 
 == Introduction
 
-The base jenkins slave used by all ODS https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves[builder slaves]
+The base jenkins slave used by all ODS https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-slaves[builder slaves]
 
 == Features / Plugins
 

--- a/infrastructure-setup/scripts/checkout-repositories.sh
+++ b/infrastructure-setup/scripts/checkout-repositories.sh
@@ -38,22 +38,22 @@ if [ ! -d "$OPENDEVSTACK_BASE_DIR/ods-provisioning-app" ] ; then
   git fetch origin
   git checkout -b production
 else
-  echo "Update shared library"
+  echo "Update provisioning app"
   cd $OPENDEVSTACK_BASE_DIR/ods-provisioning-app
   git fetch origin
   git pull origin
 fi
 
-echo -e "\nPrepare ods-project-quickstarters"
+echo -e "\nPrepare ods-quickstarters"
 cd ${OPENDEVSTACK_BASE_DIR}
-if [ ! -d "$OPENDEVSTACK_BASE_DIR/ods-project-quickstarters" ] ; then
-  git clone https://github.com/opendevstack/ods-project-quickstarters.git
-  cd ods-project-quickstarters
+if [ ! -d "$OPENDEVSTACK_BASE_DIR/ods-quickstarters" ] ; then
+  git clone https://github.com/opendevstack/ods-quickstarters.git
+  cd ods-quickstarters
   git fetch origin
   git checkout -b production
 else
-  echo "Update shared library"
-  cd $OPENDEVSTACK_BASE_DIR/ods-project-quickstarters
+  echo "Update quickstarters"
+  cd $OPENDEVSTACK_BASE_DIR/ods-quickstarters
   git pull origin
 fi
 

--- a/infrastructure-setup/scripts/create-configuration-from-sample.sh
+++ b/infrastructure-setup/scripts/create-configuration-from-sample.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# We assume that all ods repositories are placed next to each other
-# By default it is one level up from this script
+# We assume that all ODS repositories are placed next to each other.
+# By default it is one level up from this script.
 
 ODS_DIR="../../.."
 ODS_SAMPLE_DIR=`realpath ${ODS_DIR}/ods-core/configuration-sample`

--- a/infrastructure-setup/scripts/mirror-repos.sh
+++ b/infrastructure-setup/scripts/mirror-repos.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# This scripts mirros the core ods repos into your own Bitbucket server.
+# This scripts mirrors ODS repos into your own Bitbucket server.
 # By default, this is the Bitbucket server on your local machine as created by the getting started guide.
-# You can cutomize this by providing an environment variable: "REPO_TARGET_BASE" pointing to your git repo.
+# You can customize this by providing an environment variable: "REPO_TARGET_BASE" pointing to your Git repo.
 # This includes everything before the project / repo part, this means everything before "/opendevstack/..."
-#
+
 source ../../local.config
 
 BASE_DIR=${OPENDEVSTACK_DIR:-"/tmp"}
@@ -18,11 +18,6 @@ fi
 cd $BASE_DIR
 
 echo -e "Clone repositories"
-echo -e "\nPrepare ods-configuration-sample"
-git clone --bare https://github.com/opendevstack/ods-configuration-sample.git
-cd ods-configuration-sample.git; git remote add --mirror=push downstream ${TARGET_REPO_BASE}/opendevstack/ods-configuration-sample.git; cd -
-cd ods-configuration-sample.git; git branch production; git config http.postBuffer 524288000; git push downstream; cd -
-rm -rf ods-configuration-sample.git
 
 echo -e "\nPrepare ods-core"
 git clone --bare https://github.com/opendevstack/ods-core.git
@@ -43,10 +38,10 @@ cd ods-provisioning-app.git; git remote add --mirror=push downstream ${TARGET_RE
 cd ods-provisioning-app.git; git branch production; git config http.postBuffer 524288000; git push downstream; cd -
 rm -rf ods-provisioning-app.git
 
-echo -e "\nPrepare ods-project-quickstarters"
-git clone --bare https://github.com/opendevstack/ods-project-quickstarters.git
-cd ods-project-quickstarters.git; git remote add --mirror=push downstream ${TARGET_REPO_BASE}/opendevstack/ods-project-quickstarters.git; cd -
-cd ods-project-quickstarters.git; git branch production; git config http.postBuffer 524288000; git push downstream; cd -
-rm -rf ods-project-quickstarters.git
+echo -e "\nPrepare ods-quickstarters"
+git clone --bare https://github.com/opendevstack/ods-quickstarters.git
+cd ods-quickstarters.git; git remote add --mirror=push downstream ${TARGET_REPO_BASE}/opendevstack/ods-quickstarters.git; cd -
+cd ods-quickstarters.git; git branch production; git config http.postBuffer 524288000; git push downstream; cd -
+rm -rf ods-quickstarters.git
 
 cd ${cwd}

--- a/infrastructure-setup/scripts/mirror-repositories-to-gitserver.sh
+++ b/infrastructure-setup/scripts/mirror-repositories-to-gitserver.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This scripts mirros the core ods repos into your own Bitbucket server.
+# This scripts mirrors the ODS repos into your own Bitbucket server.
 # By default, this is the Bitbucket server on your local machine as created by the getting started guide.
 # You can cutomize this by providing an environment variable: "REPO_TARGET_BASE" pointing to your git repo.
 # This includes everything before the project / repo part, this means everything before "/opendevstack/..."
@@ -16,9 +16,6 @@ if [ ! -d "$BASE_DIR" ] ; then
 fi
 
 echo -e "Mirror repositories"
-echo -e "\nMirror ods-configuration-sample"
-cd ${BASE_DIR}
-cd ods-configuration-sample; git remote set-url origin ${TARGET_REPO_BASE}/opendevstack/ods-configuration-sample.git; git config http.postBuffer 524288000; git push --all origin;
 
 echo -e "\nMirror ods-configuration"
 cd ${BASE_DIR}
@@ -36,9 +33,9 @@ echo -e "\nMirror ods-provisioning-app"
 cd ${BASE_DIR}
 cd ods-provisioning-app; git remote set-url origin ${TARGET_REPO_BASE}/opendevstack/ods-provisioning-app.git; git config http.postBuffer 524288000; git push --all origin;
 
-echo -e "\nMirror ods-project-quickstarters"
+echo -e "\nMirror ods-quickstarters"
 cd ${BASE_DIR}
-cd ods-project-quickstarters; git remote set-url origin ${TARGET_REPO_BASE}/opendevstack/ods-project-quickstarters.git; git config http.postBuffer 524288000; git push --all origin;
+cd ods-quickstarters; git remote set-url origin ${TARGET_REPO_BASE}/opendevstack/ods-quickstarters.git; git config http.postBuffer 524288000; git push --all origin;
 
 
 cd ${cwd}

--- a/infrastructure-setup/scripts/prepare-openshift-cluster.sh
+++ b/infrastructure-setup/scripts/prepare-openshift-cluster.sh
@@ -14,9 +14,9 @@ fi
 # set sufficient max map count for elastic search pods (also used by sonar)
 sysctl -w vm.max_map_count=262144
 
-configuration_location=${BASE_DIR}/ods-configuration/ods-project-quickstarters/ocp-templates/templates/templates.env
-if [[ ! -f $configuration_location ]]; then
-	echo "Cannot find file: ${configuration_location} - please ensure you have copied ods-configuration-sample and created template.env"
+cd_user_config_location=${BASE_DIR}/ods-configuration/ods-core.env
+if [[ ! -f $cd_user_config_location ]]; then
+	echo "Cannot find file: ${cd_user_config_location} - please ensure you have created the ods-configuration repo (through ods-core/configuration-sample/update)"
 	exit 1
 fi
 
@@ -36,9 +36,9 @@ oc adm policy --as system:admin add-cluster-role-to-user cluster-admin system:se
 echo -e "Save token to use in rundeck for deployment in ${BASE_DIR}/openshift-api-token\n"
 oc sa get-token deployment -n cd > ${BASE_DIR}/openshift-api-token
 
-# create secrets for cd_user
-CD_USER_PWD=$(grep CD_USER_PWD $configuration_location | cut -d '=' -f 2-)
-oc process -f ${BASE_DIR}/ods-project-quickstarters/ocp-templates/ocp-config/cd-user/secret.yml -p CD_USER_PWD=${CD_USER_PWD} |  oc create -n cd -f-
+# create secrets for global cd_user
+CD_USER_PWD_B64=$(grep CD_USER_PWD_B64 $cd_user_config_location | cut -d '=' -f 2-)
+oc process -f ${BASE_DIR}/ods-core/create-projects/ocp-config/cd-user/secret.yml -p CD_USER_PWD_B64=${CD_USER_PWD_B64} |  oc create -n cd -f-
 
 if [[ ! -d "${BASE_DIR}/certs" ]] ; then
   echo "creating certs directory"

--- a/jenkins/slave-base/README.md
+++ b/jenkins/slave-base/README.md
@@ -1,7 +1,7 @@
 # ODS Jenkins Slave base
 
 ## Introduction
-The base jenkins slave used by all ODS [builder slaves](https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves)
+The base jenkins slave used by all ODS [builder slaves](https://github.com/opendevstack/ods-quickstarters/tree/master/jenkins-slaves)
 
 ## Features / Plugins
 1. Creates trust relationship with applications in the openshift cluster (thru certificate management)

--- a/shared-images/README.md
+++ b/shared-images/README.md
@@ -1,6 +1,6 @@
 # ODS Shared images
 
-Images used in [ods-project-quickstarters](https://github.com/opendevstack/ods-project-quickstarters), e.g. Airflow
+Images used in [ods-quickstarters](https://github.com/opendevstack/ods-quickstarters), e.g. Airflow.
 
 ## Contents
 

--- a/shared-images/elasticsearch/README.md
+++ b/shared-images/elasticsearch/README.md
@@ -6,7 +6,7 @@ This provide a containerized [ElasticSearch](https://www.elastic.co/products/ela
 
 ## Templates
 
-There is 4 templates used for creating ElasticSearch instances in [ODS Project QuickStarters Template folder in GitHub](https://github.com/opendevstack/ods-project-quickstarters/tree/master/ocp-templates/templates/elasticsearch)
+There is 4 templates used for creating ElasticSearch instances in [ODS Project QuickStarters Template folder in GitHub](https://github.com/opendevstack/ods-quickstarters/tree/master/common/ocp-templates/templates/elasticsearch)
 
 * `elasticsearch-ephemeral-master-template.yaml` : Ephemeral ElasticSearch master node and Kibana
 * `elasticsearch-persistent-master-template.yaml` : Persistent ElasticSearch master node and Kibana


### PR DESCRIPTION
Also removes references to ods-configuration-sample and fixes
incorrect paths to configuration.

Just trying to adjust all paths and references ... not sure if I am still missing more and if the `cd_user` thing is what you really want ...