### PR TITLE
Rename ODS_VERSION to ODS_IMAGE_TAG

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -2,8 +2,9 @@
 # Global configuration for OpenDevStack - all common params are here #
 ######################################################################
 
-# OpenDevStack version. This will be used e.g. to tag images.
-ODS_VERSION=latest
+# OpenDevStack image tag. This will be used e.g. to tag images in the 'cd'
+# namespace such as jenkins-master, jenkins-slave-base etc.
+ODS_IMAGE_TAG=latest
 # OpenDevStack source code Git reference. This will be used e.g. to configure
 # which Dockerfiles are used to build the images. Use e.g. a branch like "2.x"
 # or "3.x" if you want a vanilla install, or a custom branch like "production"

--- a/create-projects/Jenkinsfile
+++ b/create-projects/Jenkinsfile
@@ -1,4 +1,6 @@
 // BuildConfig environment variables
+def odsImageTag = env.ODS_IMAGE_TAG ?: 'latest'
+def odsGitRef = env.ODS_GIT_REF ?: 'production'
 def projectId = env.PROJECT_ID
 def projectAdmins = env.PROJECT_ADMIN
 def projectGroups = env.PROJECT_GROUPS
@@ -16,7 +18,7 @@ def gitIsHttps = false
 
 def conts = containerTemplate(
   name: 'jnlp',
-  image: "${dockerRegistry}/cd/jenkins-slave-base",
+  image: "${dockerRegistry}/cd/jenkins-slave-base:${odsImageTag}",
   workingDir: '/tmp',
   alwaysPullImage: true,
   args: ''
@@ -45,7 +47,7 @@ podTemplate(
       def bitbucketUrl = bitbucketScheme + bitbucketHost;
       checkout([
         $class: 'GitSCM',
-        branches: [[name: '*/master']],
+        branches: [[name: "*/${odsGitRef}"]],
         doGenerateSubmoduleConfigurations: false,
         extensions: [[
           $class: 'RelativeTargetDirectory',

--- a/create-projects/ocp-config/cd-jenkins/cd-jenkins-master.yml
+++ b/create-projects/ocp-config/cd-jenkins/cd-jenkins-master.yml
@@ -3,8 +3,8 @@ kind: Template
 labels:
   template: cd-jenkins-template
 parameters:
-- name: ODS_VERSION
-  description: OpenDevStack version to use.
+- name: ODS_IMAGE_TAG
+  description: OpenDevStack image tag to use.
   required: true
 - name: PROJECT
   required: true
@@ -247,7 +247,7 @@ objects:
             - jenkins
           from:
             kind: ImageStreamTag
-            name: 'jenkins-master:${ODS_VERSION}'
+            name: 'jenkins-master:${ODS_IMAGE_TAG}'
             namespace: '${NAMESPACE}'
           lastTriggeredImage: ''
         type: ImageChange

--- a/create-projects/ocp-config/cd-jenkins/cd-jenkins-webhook-proxy.yml
+++ b/create-projects/ocp-config/cd-jenkins/cd-jenkins-webhook-proxy.yml
@@ -3,8 +3,8 @@ kind: Template
 labels:
   template: cd-jenkins-template
 parameters:
-- name: ODS_VERSION
-  description: OpenDevStack version to use.
+- name: ODS_IMAGE_TAG
+  description: OpenDevStack image tag to use.
   required: true
 - name: PROJECT
   required: true
@@ -110,7 +110,7 @@ objects:
         - webhook-proxy
         from:
           kind: ImageStreamTag
-          name: jenkins-webhook-proxy:${ODS_VERSION}
+          name: jenkins-webhook-proxy:${ODS_IMAGE_TAG}
           namespace: '${NAMESPACE}'
       type: ImageChange
 - apiVersion: v1

--- a/jenkins/ocp-config/bc.yml
+++ b/jenkins/ocp-config/bc.yml
@@ -40,7 +40,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: 'jenkins-master:${ODS_VERSION}'
+        name: 'jenkins-master:${ODS_IMAGE_TAG}'
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -52,7 +52,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: 'jenkins-slave-base:${ODS_VERSION}'
+        name: 'jenkins-slave-base:${ODS_IMAGE_TAG}'
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -89,7 +89,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: 'jenkins-webhook-proxy:${ODS_VERSION}'
+        name: 'jenkins-webhook-proxy:${ODS_IMAGE_TAG}'
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -109,8 +109,8 @@ objects:
     nodeSelector: null
     triggers: []
 parameters:
-- name: ODS_VERSION
-  description: OpenDevStack version to use.
+- name: ODS_IMAGE_TAG
+  description: OpenDevStack image tag to use.
   required: true
 - name: ODS_GIT_REF
   description: Git ref to use for source code.

--- a/shared-images/ocp-config/bc.yml
+++ b/shared-images/ocp-config/bc.yml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: Template
+parameters:
+- name: REPO_BASE
+  description: repository base url. In case bitbucket is used, needs to include /scm - so it's the path in front on opendevstack/..
+  required: true
+- name: ODS_GIT_REF
+  required: true
 objects:
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -23,7 +29,7 @@ objects:
     source:
       contextDir: shared-images/elasticsearch
       git:
-        ref: production
+        ref: ${ODS_GIT_REF}
         uri: ${REPO_BASE}/opendevstack/ods-core.git
       sourceSecret:
         name: cd-user-token
@@ -55,7 +61,7 @@ objects:
     source:
       contextDir: shared-images/airflow
       git:
-        ref: production
+        ref: ${ODS_GIT_REF}
         uri: ${REPO_BASE}/opendevstack/ods-core.git
       sourceSecret:
         name: cd-user-token
@@ -65,7 +71,3 @@ objects:
         dockerfilePath: Dockerfile
       type: Docker
     triggers: []
-parameters:
-- name: REPO_BASE
-  description: repository base url. In case bitbucket is used, needs to include /scm - so it's the path in front on opendevstack/..
-  required: true

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -15,7 +15,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: sonarqube:${ODS_VERSION}
+        name: sonarqube:${ODS_IMAGE_TAG}
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -164,7 +164,7 @@ objects:
       spec:
         containers:
         - name: sonarqube
-          image: cd/sonarqube:${ODS_VERSION}
+          image: cd/sonarqube:${ODS_IMAGE_TAG}
           env:
           - name: SONARQUBE_JDBC_URL
             valueFrom:
@@ -231,7 +231,7 @@ objects:
         - sonarqube
         from:
           kind: ImageStreamTag
-          name: sonarqube:${ODS_VERSION}
+          name: sonarqube:${ODS_IMAGE_TAG}
           namespace: cd
       type: ImageChange
 - apiVersion: v1
@@ -384,8 +384,8 @@ objects:
     sessionAffinity: None
     type: ClusterIP
 parameters:
-- name: ODS_VERSION
-  description: OpenDevStack version to use.
+- name: ODS_IMAGE_TAG
+  description: OpenDevStack image tag to use.
   required: true
 - name: ODS_GIT_REF
   description: Git ref to use for source code.


### PR DESCRIPTION
The new name makes the purpose clearer (and aligns with https://github.com/opendevstack/ods-quickstarters/pull/49).

Also, this commit contains cleanup of the usage of the params.