### PR TITLE
Removing type -P and --force from script

### DIFF
--- a/create-projects/Jenkinsfile
+++ b/create-projects/Jenkinsfile
@@ -68,7 +68,7 @@ podTemplate(
     }
 
     stage('creating jenkins') {
-      sh "sh ./create-projects/create-cd-jenkins.sh --force"
+      sh "sh ./create-projects/create-cd-jenkins.sh --force --verbose"
     }
   }
 }

--- a/create-projects/Jenkinsfile
+++ b/create-projects/Jenkinsfile
@@ -68,7 +68,7 @@ podTemplate(
     }
 
     stage('creating jenkins') {
-      sh "sh ./create-projects/create-cd-jenkins.sh"
+      sh "sh ./create-projects/create-cd-jenkins.sh --force"
     }
   }
 }

--- a/create-projects/create-cd-jenkins.sh
+++ b/create-projects/create-cd-jenkins.sh
@@ -1,80 +1,82 @@
 #!/usr/bin/env bash
-set -eux
+set -eu
 
 # This script sets up the cd/jenkins-master and the associated webhook proxy.
 
 # support pointing to patched tailor using TAILOR environment variable
-: ${TAILOR:=tailor}
 
-tailor_exe=$(type -P ${TAILOR})
-tailor_version=$(${TAILOR} version)
-
-echo "Using tailor ${tailor_version} from ${tailor_exe}"
-
+TAILOR="tailor"
 DEBUG=false
 STATUS=false
-while [[ $# -gt 0 ]]
-do
-key="$1"
+FORCE=""
 
-case $key in
-    --status)
-    STATUS=true
-    ;;
-    -d|--debug)
-    DEBUG=true;
-    shift
-    ;;
-    *)
-        echo "Unknown option: $1. Exiting."
-        exit 1
-    ;;
-esac
-shift # past argument or value
-done
+function usage {
+   printf "usage: %s [options]\n", $0
+   printf "\t--status\tExecutes tailor status\n"
+   printf "\t--force\tIgnores warnings and error with tailor --force\n"
+   printf "\t-h|--help\tPrints the usage\n"
+   printf "\t-d|--debug\tEnabled debug\n"
+   printf "\t-t|--tailor\tChanges the executable of tailor. Default: tailor\n"
 
+}
+
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+   --status) STATUS=true;;
+   -d|--debug) DEBUG=true; set -x;;
+   --force) FORCE="--force"; ;;
+   -h|--help) usage; exit 0;;
+   -t=*|--tailor=*) TAILOR="${1#*=}";;
+   -t|--tailor) TAILOR="$2"; shift;;
+
+   *) echo "Unknown parameter passed: $1"; usage; exit 1;;
+ esac; shift; done
+
+echo "Current tailor version is: $(${TAILOR} version)"
+exit 1
 if $DEBUG; then
   tailor_verbose="-v"
 else
   tailor_verbose=""
 fi
 
-tailor_verbose+=" --force"
-
 if [ -z ${PROJECT_ID+x} ]; then
-    echo "PROJECT_ID is unset, but required";
-    exit 1;
+  echo "PROJECT_ID is unset, but required"
+  exit 1
 else echo "PROJECT_ID=${PROJECT_ID}"; fi
 
 if $STATUS; then
   echo "NOTE: Invoked with --status:  will use tailor status instead of tailor update."
 fi
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 tailor_update_in_dir() {
-    local dir="$1"; shift
-    if [ ${STATUS} = "true" ]; then
-        $DEBUG && echo 'exec:' cd  "$dir" '&&'
-        $DEBUG && echo 'exec:'     ${TAILOR} $tailor_verbose status "$@"
-        cd "$dir" && ${TAILOR} $tailor_verbose status "$@"
-    else
-        $DEBUG && echo 'exec:' cd "$dir" '&&'
-        $DEBUG && echo 'exec:    ' ${TAILOR} $tailor_verbose --non-interactive update "$@"
-        cd "$dir" && ${TAILOR} $tailor_verbose --non-interactive update "$@"
-    fi
+  local dir="$1"
+  shift
+  if [ ${STATUS} = "true" ]; then
+    $DEBUG && echo 'exec:' cd "$dir" '&&'
+    $DEBUG && echo 'exec:' ${TAILOR} $tailor_verbose status "$@"
+    cd "$dir" && ${TAILOR} $tailor_verbose ${FORCE} status "$@"
+  else
+    $DEBUG && echo 'exec:' cd "$dir" '&&'
+    $DEBUG && echo 'exec:    ' ${TAILOR} $tailor_verbose --non-interactive update "$@"
+    cd "$dir" && ${TAILOR} $tailor_verbose ${FORCE} --non-interactive update "$@"
+  fi
 }
 
 cdUserPwdParam=""
-if [ $CD_USER_TYPE != "general" ]; then
-    base64Pwd=$(echo -n "changeme" | base64)
-    cdUserPwdParam="--param=CD_USER_PWD_B64=${base64Pwd}"
+if [ "${CD_USER_TYPE}" != "general" ]; then
+  base64Pwd=$(echo -n "changeme" | base64)
+  cdUserPwdParam="--param=CD_USER_PWD_B64=${base64Pwd}"
 fi
 
+
+
 tailor_update_in_dir "${SCRIPT_DIR}/ocp-config/cd-jenkins" \
-    "--namespace=${PROJECT_ID}-cd" \
-    "--param=PROXY_TRIGGER_SECRET_B64=${PIPELINE_TRIGGER_SECRET}" \
-    "--param=PROJECT=${PROJECT_ID}" \
-    "--param=CD_USER_ID_B64=${CD_USER_ID_B64}" \
-    $cdUserPwdParam \
-    --selector "template=cd-jenkins-template"
+  "--namespace=${PROJECT_ID}-cd" \
+  "--param=PROXY_TRIGGER_SECRET_B64=${PIPELINE_TRIGGER_SECRET}" \
+  "--param=PROJECT=${PROJECT_ID}" \
+  "--param=CD_USER_ID_B64=${CD_USER_ID_B64}" \
+  $cdUserPwdParam \
+  --selector "template=cd-jenkins-template"

--- a/create-projects/create-cd-jenkins.sh
+++ b/create-projects/create-cd-jenkins.sh
@@ -6,7 +6,7 @@ set -eu
 # support pointing to patched tailor using TAILOR environment variable
 
 TAILOR="tailor"
-DEBUG=false
+VERBOSE=false
 STATUS=false
 FORCE=""
 
@@ -15,7 +15,7 @@ function usage {
    printf "\t--status\tExecutes tailor status\n"
    printf "\t--force\tIgnores warnings and error with tailor --force\n"
    printf "\t-h|--help\tPrints the usage\n"
-   printf "\t-d|--debug\tEnabled debug\n"
+   printf "\t-v|--verbose\tVerbose output\n"
    printf "\t-t|--tailor\tChanges the executable of tailor. Default: tailor\n"
 
 }
@@ -23,9 +23,13 @@ function usage {
 
 while [[ "$#" -gt 0 ]]; do case $1 in
    --status) STATUS=true;;
-   -d|--debug) DEBUG=true; set -x;;
+
+   -v|--verbose) VERBOSE=true; set -x;;
+
    --force) FORCE="--force"; ;;
+
    -h|--help) usage; exit 0;;
+
    -t=*|--tailor=*) TAILOR="${1#*=}";;
    -t|--tailor) TAILOR="$2"; shift;;
 
@@ -34,7 +38,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 
 echo "Current tailor version is: $(${TAILOR} version)"
 exit 1
-if $DEBUG; then
+if $VERBOSE; then
   tailor_verbose="-v"
 else
   tailor_verbose=""
@@ -55,12 +59,12 @@ tailor_update_in_dir() {
   local dir="$1"
   shift
   if [ ${STATUS} = "true" ]; then
-    $DEBUG && echo 'exec:' cd "$dir" '&&'
-    $DEBUG && echo 'exec:' ${TAILOR} ${FORCE} $tailor_verbose status "$@"
+    $VERBOSE && echo 'exec:' cd "$dir" '&&'
+    $VERBOSE && echo 'exec:' ${TAILOR} ${FORCE} $tailor_verbose status "$@"
     cd "$dir" && ${TAILOR} $tailor_verbose ${FORCE} status "$@"
   else
-    $DEBUG && echo 'exec:' cd "$dir" '&&'
-    $DEBUG && echo 'exec:    ' ${TAILOR} ${FORCE} $tailor_verbose --non-interactive update "$@"
+    $VERBOSE && echo 'exec:' cd "$dir" '&&'
+    $VERBOSE && echo 'exec:    ' ${TAILOR} ${FORCE} $tailor_verbose --non-interactive update "$@"
     cd "$dir" && ${TAILOR} $tailor_verbose ${FORCE} --non-interactive update "$@"
   fi
 }

--- a/create-projects/create-cd-jenkins.sh
+++ b/create-projects/create-cd-jenkins.sh
@@ -37,7 +37,7 @@ while [[ "$#" -gt 0 ]]; do case $1 in
  esac; shift; done
 
 echo "Current tailor version is: $(${TAILOR} version)"
-exit 1
+
 if $VERBOSE; then
   tailor_verbose="-v"
 else

--- a/create-projects/create-cd-jenkins.sh
+++ b/create-projects/create-cd-jenkins.sh
@@ -56,11 +56,11 @@ tailor_update_in_dir() {
   shift
   if [ ${STATUS} = "true" ]; then
     $DEBUG && echo 'exec:' cd "$dir" '&&'
-    $DEBUG && echo 'exec:' ${TAILOR} $tailor_verbose status "$@"
+    $DEBUG && echo 'exec:' ${TAILOR} ${FORCE} $tailor_verbose status "$@"
     cd "$dir" && ${TAILOR} $tailor_verbose ${FORCE} status "$@"
   else
     $DEBUG && echo 'exec:' cd "$dir" '&&'
-    $DEBUG && echo 'exec:    ' ${TAILOR} $tailor_verbose --non-interactive update "$@"
+    $DEBUG && echo 'exec:    ' ${TAILOR} ${FORCE} $tailor_verbose --non-interactive update "$@"
     cd "$dir" && ${TAILOR} $tailor_verbose ${FORCE} --non-interactive update "$@"
   fi
 }


### PR DESCRIPTION
This PR refers to the issues https://github.com/opendevstack/ods-core/issues/331, https://github.com/opendevstack/ods-core/issues/335 and https://github.com/opendevstack/ods-core/issues/336

In the script https://github.com/opendevstack/ods-core/blob/master/create-projects/create-cd-jenkins.sh:

- It removes the `type -P`
- Refactor the command line parser adding usage 
- Remove the --force from the script and adds it as a argument to the script
- Add in the Jenkins file --force to keep compatibility

\closes https://github.com/opendevstack/ods-core/issues/331
\closes https://github.com/opendevstack/ods-core/issues/335
\closes https://github.com/opendevstack/ods-core/issues/336