### PR TITLE
Fixed drifts of templates

### DIFF
--- a/create-projects/ocp-config/cd-jenkins/cd-jenkins-master.yml
+++ b/create-projects/ocp-config/cd-jenkins/cd-jenkins-master.yml
@@ -267,7 +267,7 @@ objects:
     name: '${JENKINS_SERVICE_NAME}'
     labels:
       template: cd-jenkins-master
-- apiVersion: v1
+- apiVersion: rbac.authorization.k8s.io/v1
   groupNames: null
   kind: RoleBinding
   metadata:
@@ -276,6 +276,8 @@ objects:
       template: cd-jenkins-master
   roleRef:
     name: edit
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
   subjects:
     - kind: ServiceAccount
       name: '${JENKINS_SERVICE_NAME}'

--- a/create-projects/ocp-config/cd-jenkins/cd-jenkins-webhook-proxy.yml
+++ b/create-projects/ocp-config/cd-jenkins/cd-jenkins-webhook-proxy.yml
@@ -20,7 +20,6 @@ objects:
 - apiVersion: v1
   kind: Route
   metadata:
-    annotations: {}
     labels:
       template: cd-jenkins-webhook-proxy
       app: jenkins-webhook-proxy
@@ -38,7 +37,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    annotations: {}
     labels:
       template: cd-jenkins-webhook-proxy
       app: jenkins-webhook-proxy
@@ -77,7 +75,6 @@ objects:
       type: Rolling
     template:
       metadata:
-        annotations: {}
         labels:
           app: jenkins-webhook-proxy
       spec:


### PR DESCRIPTION
Templates fixed:

- Removed `annotations: {}` from create-projects/ocp-config/cd-jenkins/cd-jenkins-webhook-proxy.yml 
- Added missing values to create-projects/ocp-config/cd-jenkins/cd-jenkins-master.yml

Closes #339 