### PR TITLE
Adding port option to APP_DNS for fetching certificates

### DIFF
--- a/jenkins/master/import_certs.sh
+++ b/jenkins/master/import_certs.sh
@@ -4,6 +4,8 @@ oldIFS=$IFS
 IFS=';'
 KEYSTORE="$JAVA_HOME/lib/security/cacerts"
 
+: "${APP_DNS_PORT:=443}"
+
 if [ "${TARGET_HOSTS}x" == "x" ] ; then
     TARGET_HOSTS=${APP_DNS}
 fi
@@ -11,7 +13,7 @@ fi
 echo "KEYSTORE=${KEYSTORE}"
 for dns in $TARGET_HOSTS; do
     cert_bundle_path="/etc/pki/ca-trust/source/anchors/${dns}.pem"
-    gnutls-cli --insecure --print-cert ${dns} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee ${cert_bundle_path}    
+    gnutls-cli --insecure --print-cert ${dns} -p ${APP_DNS_PORT} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee ${cert_bundle_path}    
     $JAVA_HOME/bin/keytool -import -noprompt -trustcacerts -file ${cert_bundle_path} -alias ${dns} -keystore ${KEYSTORE} -storepass changeit || true
 done
 update-ca-trust

--- a/jenkins/ocp-config/bc.yml
+++ b/jenkins/ocp-config/bc.yml
@@ -31,6 +31,8 @@ objects:
         env:
           - name: APP_DNS
             value: ${APP_DNS}
+          - name: APP_DNS_PORT
+            value: ${APP_DNS_PORT}
           - name: TARGET_HOSTS
             value: ${TARGET_HOSTS}
         from:
@@ -70,6 +72,8 @@ objects:
         env:
           - name: APP_DNS
             value: ${APP_DNS}
+          - name: APP_DNS_PORT
+            value: ${APP_DNS_PORT}
           - name: SNYK_DISTRIBUTION_URL
             value: ${JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL}
           - name: TARGET_HOSTS
@@ -124,6 +128,8 @@ parameters:
   description: configuration which agent base to use, for rhel7 use registry.access.redhat.com/openshift3/jenkins-slave-base-rhel7
 - name: APP_DNS
   description: OpenShift application base dns - used for grabbing the root ca and adding into the agent
+- name: APP_DNS_PORT
+  description: OpenShift application base dns port - used for grabbing the root ca and adding into the agent
 - name: JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL
   description: optional uri that points to the snyk binary distribution (i.e. https://github.com/snyk/snyk/releases/download/v1.180.1/snyk-linux)
 - name: TARGET_HOSTS

--- a/jenkins/slave-base/Dockerfile.centos7
+++ b/jenkins/slave-base/Dockerfile.centos7
@@ -13,6 +13,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     OSTREE_VERSION=2018.5-1
 
 ARG APP_DNS=192.168.99.100.nip.io
+ARG APP_DNS_PORT=443
 ARG SNYK_DISTRIBUTION_URL
 
 RUN yum -y install \
@@ -29,7 +30,7 @@ RUN yum -y install java-1.8.0-openjdk-devel.x86_64 \
 
 # Fetch certificates and store them in tmp directory.
 RUN echo ${APP_DNS} \
-    && gnutls-cli --insecure --print-cert ${APP_DNS} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/oc_app.crt
+    && gnutls-cli --insecure --print-cert ${APP_DNS} -p ${APP_DNS_PORT} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/oc_app.crt
 
 # Add root ca into cert store so OC can pick it up.
 RUN cat /tmp/oc_app.crt >> /etc/ssl/certs/ca-bundle.trust.crt \

--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -13,6 +13,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     OSTREE_VERSION=2018.5-1
 
 ARG APP_DNS=192.168.99.100.nip.io
+ARG APP_DNS_PORT=443
 ARG SNYK_DISTRIBUTION_URL
 
 RUN yum -y install \
@@ -29,7 +30,7 @@ RUN yum -y install java-1.8.0-openjdk-devel.x86_64 \
 
 # Fetch certificates and store them in tmp directory.
 RUN echo ${APP_DNS} \
-    && gnutls-cli --insecure --print-cert ${APP_DNS} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/oc_app.crt
+    && gnutls-cli --insecure --print-cert ${APP_DNS} -p ${APP_DNS_PORT} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/oc_app.crt
 
 # Add root ca into cert store so OC can pick it up.
 RUN cat /tmp/oc_app.crt >> /etc/ssl/certs/ca-bundle.trust.crt \


### PR DESCRIPTION
\closes #350 

Added APP_DNS_PORT to all calls of `gnutls-cli` during Jenkins build and set the default to 443