### PR TITLE
Set cd namespace again in Tailorfile

### DIFF
--- a/jenkins/ocp-config/Tailorfile
+++ b/jenkins/ocp-config/Tailorfile
@@ -1,3 +1,4 @@
+namespace cd
 selector app=jenkins
 param-file ../../../ods-configuration/ods-core.env
 ignore-unknown-parameters true


### PR DESCRIPTION
https://github.com/opendevstack/ods-core/commit/d490a65433724969b8d8d6a36b34ffa4942900ab#diff-85fd476ff2a51790f8ae57382c6c7a2e removed `namespace cd` from the `Tailorfile` in `jenkins/ocp-config`. This should not be the case as having a fixed namespace prevents possible errors.