### PR TITLE
Add missing SONAR_ADMIN_PASSWORD_B64 param for 2.x

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -40,9 +40,14 @@ SONARQUBE_HOST=sonarqube-cd.192.168.56.101.nip.io
 # SonarQube URL exposed by the SonarQube route
 SONARQUBE_URL=https://sonarqube-cd.192.168.56.101.nip.io
 
-# Username and password for SonarQube
+# Username of SonarQube administrator
 SONAR_ADMIN_USERNAME=admin
-SONAR_DATABASE_PASSWORD_B64=changeme
+# Password of SonarQube administrator - should be set to a secure password
+# of your choice.
+SONAR_ADMIN_PASSWORD_B64=changeme
+# Authentication token used by sonar-scanner-cli from Jenkins pipelines.
+# The token has to be created after the installation of SonarQube in the web
+# interface.
 SONAR_AUTH_TOKEN_B64=changeme
 
 # Application in Crowd used for authentication


### PR DESCRIPTION
Fixes #375 for 2.x.

Also improves documentation of parameters.