### PR TITLE
Use HTTPS in curl command

### DIFF
--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -47,7 +47,8 @@ RUN cd /tmp \
     && curl -LOv https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli \
-    && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip
+    && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
+    && /usr/local/sonar-scanner-cli/bin/sonar-scanner --version
 ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
 
 # Install OWASP Dependency Check CLI.

--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -44,7 +44,7 @@ RUN echo $JAVA_HOME \
 
 # Install Sonar Scanner.
 RUN cd /tmp \
-    && curl -LOv http://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
+    && curl -LOv https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli \
     && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip


### PR DESCRIPTION
Fixes #378.

Also prints the version of sonar-scanner to align with other binaries.

Skopeo is also downloaded using HTTP URLs, but testing showed that apparently HTTPS is not supported there (yet).