### PR TITLE
Move ODS config to Jenkins master

### DIFF
--- a/jenkins/master/Dockerfile
+++ b/jenkins/master/Dockerfile
@@ -1,7 +1,12 @@
 FROM openshift/jenkins-2-centos7
 
 ENV JAVA_HOME /usr/lib/jvm/jre
+
 ARG APP_DNS=192.168.99.100.nip.io
+ARG ODS_GIT_REF
+ARG ODS_IMAGE_TAG
+ARG SONAR_EDITION
+ARG SONAR_VERSION
 
 USER root
 RUN yum -y install openssl gnutls-utils \
@@ -9,10 +14,11 @@ RUN yum -y install openssl gnutls-utils \
     && yum clean all  \
     && rm -rf /var/cache/yum/*
 
-# fetch certificates and store them in tmp directory
+# Fetch certificates and store them in tmp directory.
 COPY ./import_certs.sh /usr/local/bin/import_certs.sh
 RUN import_certs.sh
 
+# Copy configuration and plugins.
 COPY plugins.txt /opt/openshift/configuration/plugins.txt
 COPY kube-slave-common.sh /usr/local/bin/kube-slave-common.sh
 RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt \
@@ -21,6 +27,15 @@ RUN /usr/local/bin/install-plugins.sh /opt/openshift/configuration/plugins.txt \
 COPY configuration/ /opt/openshift/configuration/
 COPY openshift-sync.jar /opt/openshift/
 COPY ods-run /usr/libexec/s2i/ods-run
+
+# Add ODS configuration file.
+RUN mkdir -p /etc/opendevstack \
+    && echo "{" > /etc/opendevstack/config.json \
+    && echo "  \"odsGitRef\": \"$ODS_GIT_REF\"," >> /etc/opendevstack/config.json \
+    && echo "  \"odsImageTag\": \"$ODS_IMAGE_TAG\"," >> /etc/opendevstack/config.json \
+    && echo "  \"sonarqubeEdition\": \"$SONAR_EDITION\"," >> /etc/opendevstack/config.json \
+    && echo "  \"sonarqubeVersion\": \"$SONAR_VERSION\"" >> /etc/opendevstack/config.json \
+    && echo "}" >> /etc/opendevstack/config.json
 
 USER jenkins
 ENV JENKINS_JAVA_OVERRIDES="-Dhudson.tasks.MailSender.SEND_TO_UNKNOWN_USERS=true -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true"

--- a/jenkins/master/configuration/init.groovy.d/ods-jenkins-shared-library.groovy
+++ b/jenkins/master/configuration/init.groovy.d/ods-jenkins-shared-library.groovy
@@ -1,6 +1,7 @@
 #!groovy
 
 // imports
+import groovy.json.JsonSlurper
 import hudson.scm.SCM
 import jenkins.model.Jenkins
 import jenkins.plugins.git.GitSCMSource
@@ -8,28 +9,32 @@ import org.jenkinsci.plugins.workflow.libs.*
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever
 
-def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text.trim()
-println "INFO: Jenkins adding build shared lib: ${namespace}"
-
 def buildSharedLibName = "ods-jenkins-shared-library"
 
+def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text.trim()
 def env = System.getenv()
-def buildSharedLibraryRepository = env['SHARED_LIBRARY_REPOSITORY']
-
-println "INFO: Jenkins adding ods build shared lib ${buildSharedLibName}"
-
 def credentialsId = namespace + "-cd-user-with-password"
-// parameters
+def buildSharedLibRepository = env['SHARED_LIBRARY_REPOSITORY']
+
+println "INFO: Adding global library ${buildSharedLibName}: ${buildSharedLibRepository}"
+
+// Read ODS configuration.
+def jsonSlurper = new JsonSlurper()
+def odsConfig = jsonSlurper.parse(new File("/etc/opendevstack/config.json"))
+println "INFO: Read ODS configuration ${odsConfig}"
+
+// Define parameters.
+def defaultBranch = odsConfig.odsGitRef ?: 'production'
 def globalLibrariesParameters = [
-  branch:               "production",
+  branch:               defaultBranch,
   credentialId:         credentialsId,
   implicit:             false,
   name:                 buildSharedLibName,
-  repository:           buildSharedLibraryRepository
+  repository:           buildSharedLibRepository
 ]
 
-// define global library
-GitSCMSource gitSCMSource = new GitSCMSource(
+// Define SCM retriever.
+def gitSCMSource = new GitSCMSource(
   globalLibrariesParameters.name,
   globalLibrariesParameters.repository,
   globalLibrariesParameters.credentialId,
@@ -37,37 +42,39 @@ GitSCMSource gitSCMSource = new GitSCMSource(
   "",
   false
 )
+def scmSourceRetriever = new SCMSourceRetriever(gitSCMSource)
 
-// define retriever
-SCMSourceRetriever sCMSourceRetriever = new SCMSourceRetriever(gitSCMSource)
-
-// get Jenkins instance
+// Get Jenkins instance.
 Jenkins jenkins = Jenkins.getInstance()
 
-// get Jenkins Global Libraries
+// Get global libraries.
 def globalLibraries = jenkins.getDescriptor("org.jenkinsci.plugins.workflow.libs.GlobalLibraries")
+def List<LibraryConfiguration> existingLibs = globalLibraries.get().getLibraries()
 
-// define new library configuration
-LibraryConfiguration libraryConfiguration = new LibraryConfiguration(globalLibrariesParameters.name, sCMSourceRetriever)
+// Define new library configuration.
+def libraryConfiguration = new LibraryConfiguration(
+  globalLibrariesParameters.name,
+  scmSourceRetriever
+)
 libraryConfiguration.setDefaultVersion(globalLibrariesParameters.branch)
 libraryConfiguration.setImplicit(globalLibrariesParameters.implicit)
 
-// set new Jenkins Global Library
-def List<LibraryConfiguration> existingLibs = globalLibraries.get().getLibraries()
-
-println "INFO: Found existing libraries: " + existingLibs.size
-
-for (LibraryConfiguration config : existingLibs) {
-  if (config.getName() == buildSharedLibName) {
-    println "DEBUG: lib already existing, skipping"
+// Set new global library.
+def libIndex = null
+existingLibs.eachWithIndex { item, index ->
+  if (item.getName() == buildSharedLibName) {
+    libIndex = index
+    println "INFO: Library ${buildSharedLibName} exists already"
     return
   }
 }
+if (libIndex != null) {
+  println "INFO: Replacing library ${buildSharedLibName}"
+  existingLibs[libIndex] = libraryConfiguration
+} else {
+  println "INFO: Adding library ${buildSharedLibName}"
+  existingLibs.add(libraryConfiguration)
+}
 
-println "DEBUG: Adding ODS build shared lib"
-
-// add the lib
-existingLibs.add(libraryConfiguration)
-
-// save current Jenkins state to disk
+// Save current Jenkins state to disk.
 jenkins.save()

--- a/jenkins/master/configuration/init.groovy.d/ods-mro-jenkins-shared-library.groovy
+++ b/jenkins/master/configuration/init.groovy.d/ods-mro-jenkins-shared-library.groovy
@@ -1,6 +1,7 @@
 #!groovy
 
 // imports
+import groovy.json.JsonSlurper
 import hudson.scm.SCM
 import jenkins.model.Jenkins
 import jenkins.plugins.git.GitSCMSource
@@ -8,33 +9,35 @@ import org.jenkinsci.plugins.workflow.libs.*
 import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration
 import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever
 
-def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text.trim()
-println "INFO: Jenkins adding mro shared lib into namespace: ${namespace}"
-
 def buildSharedLibName = "ods-jenkins-shared-library"
 def mroSharedLibName = "ods-mro-jenkins-shared-library"
 
+def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text.trim()
 def env = System.getenv()
-def buildSharedLibraryRepository = env['SHARED_LIBRARY_REPOSITORY']
-
-println "INFO: Jenkins adding mro shared lib - build lib path ${buildSharedLibraryRepository}"
-
-def mroLibRepoPath = buildSharedLibraryRepository.replace(buildSharedLibName, mroSharedLibName)
-
-println "INFO: Jenkins adding mro shared lib path: ${mroLibRepoPath}, name ${mroSharedLibName}"
-
 def credentialsId = namespace + "-cd-user-with-password"
-// parameters
+def buildSharedLibRepository = env['SHARED_LIBRARY_REPOSITORY']
+// Infer repository path from SHARED_LIBRARY_REPOSITORY.
+def mroSharedLibRepository = buildSharedLibRepository.replace(buildSharedLibName, mroSharedLibName)
+
+println "INFO: Adding global library ${mroSharedLibName}: ${mroSharedLibRepository}"
+
+// Read ODS configuration.
+def jsonSlurper = new JsonSlurper()
+def odsConfig = jsonSlurper.parse(new File("/etc/opendevstack/config.json"))
+println "INFO: Read ODS configuration ${odsConfig}"
+
+// Define parameters.
+def defaultBranch = odsConfig.odsGitRef ?: 'production'
 def globalLibrariesParameters = [
-  branch:               "production",
+  branch:               defaultBranch,
   credentialId:         credentialsId,
   implicit:             false,
   name:                 mroSharedLibName,
-  repository:           mroLibRepoPath
+  repository:           mroSharedLibRepository
 ]
 
-// define global library
-GitSCMSource gitSCMSource = new GitSCMSource(
+// Define SCM retriever.
+def gitSCMSource = new GitSCMSource(
   globalLibrariesParameters.name,
   globalLibrariesParameters.repository,
   globalLibrariesParameters.credentialId,
@@ -42,38 +45,39 @@ GitSCMSource gitSCMSource = new GitSCMSource(
   "",
   false
 )
+def scmSourceRetriever = new SCMSourceRetriever(gitSCMSource)
 
-// define retriever
-SCMSourceRetriever sCMSourceRetriever = new SCMSourceRetriever(gitSCMSource)
-
-// get Jenkins instance
+// Get Jenkins instance.
 Jenkins jenkins = Jenkins.getInstance()
 
-// get Jenkins Global Libraries
+// Get global libraries.
 def globalLibraries = jenkins.getDescriptor("org.jenkinsci.plugins.workflow.libs.GlobalLibraries")
+def List<LibraryConfiguration> existingLibs = globalLibraries.get().getLibraries()
 
-// define new library configuration
-LibraryConfiguration libraryConfiguration = new LibraryConfiguration(globalLibrariesParameters.name, sCMSourceRetriever)
+// Define new library configuration.
+def libraryConfiguration = new LibraryConfiguration(
+  globalLibrariesParameters.name,
+  scmSourceRetriever
+)
 libraryConfiguration.setDefaultVersion(globalLibrariesParameters.branch)
 libraryConfiguration.setImplicit(globalLibrariesParameters.implicit)
 
-// set new Jenkins Global Library
-def List<LibraryConfiguration> existingLibs = globalLibraries.get().getLibraries()
-
-println "INFO: Found existing libraries: " + existingLibs.size
-
-for (LibraryConfiguration config : existingLibs) {
-  if (config.getName() == mroSharedLibName) {
-    println "DEBUG: mro lib already existing, skipping"
+// Set new global library.
+def libIndex = null
+existingLibs.eachWithIndex { item, index ->
+  if (item.getName() == mroSharedLibName) {
+    libIndex = index
+    println "INFO: Library ${mroSharedLibName} exists already"
     return
   }
 }
+if (libIndex != null) {
+  println "INFO: Replacing library ${mroSharedLibName}"
+  existingLibs[libIndex] = libraryConfiguration
+} else {
+  println "INFO: Adding library ${mroSharedLibName}"
+  existingLibs.add(libraryConfiguration)
+}
 
-println "DEBUG: Adding MRO build shared lib"
-
-// add the lib
-existingLibs.add(libraryConfiguration)
-
-
-// save current Jenkins state to disk
+// Save current Jenkins state to disk.
 jenkins.save()

--- a/jenkins/ocp-config/bc.yml
+++ b/jenkins/ocp-config/bc.yml
@@ -84,14 +84,6 @@ objects:
             value: ${JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL}
           - name: TARGET_HOSTS
             value: ${TARGET_HOSTS}
-          - name: ODS_GIT_REF
-            value: ${ODS_GIT_REF}
-          - name: ODS_IMAGE_TAG
-            value: ${ODS_IMAGE_TAG}
-          - name: SONAR_EDITION
-            value: ${SONAR_EDITION}
-          - name: SONAR_VERSION
-            value: ${SONAR_VERSION}
         from:
           kind: DockerImage
           name: ${JENKINS_AGENT_BASE_FROM_IMAGE}

--- a/jenkins/ocp-config/bc.yml
+++ b/jenkins/ocp-config/bc.yml
@@ -33,6 +33,14 @@ objects:
             value: ${APP_DNS_PORT}
           - name: TARGET_HOSTS
             value: ${TARGET_HOSTS}
+          - name: ODS_GIT_REF
+            value: ${ODS_GIT_REF}
+          - name: ODS_IMAGE_TAG
+            value: ${ODS_IMAGE_TAG}
+          - name: SONAR_EDITION
+            value: ${SONAR_EDITION}
+          - name: SONAR_VERSION
+            value: ${SONAR_VERSION}
         from:
           kind: ImageStreamTag
           name: jenkins:2

--- a/jenkins/slave-base/Dockerfile.centos7
+++ b/jenkins/slave-base/Dockerfile.centos7
@@ -15,10 +15,6 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 ARG APP_DNS=192.168.99.100.nip.io
 ARG APP_DNS_PORT=443
 ARG SNYK_DISTRIBUTION_URL
-ARG ODS_GIT_REF
-ARG ODS_IMAGE_TAG
-ARG SONAR_EDITION
-ARG SONAR_VERSION
 
 RUN yum -y install \
     gnutls-utils \
@@ -71,15 +67,6 @@ RUN cd /tmp \
     && mkdir /usr/local/cnes \
     && mv cnesreport.jar /usr/local/cnes/ \
     && chmod 777 /usr/local/cnes/cnesreport.jar
-
-# Add ODS configuration file.
-RUN mkdir -p /etc/opendevstack \
-    && echo "{" > /etc/opendevstack/config.json \
-    && echo "  \"odsGitRef\": \"$ODS_GIT_REF\"," >> /etc/opendevstack/config.json \
-    && echo "  \"odsImageTag\": \"$ODS_IMAGE_TAG\"," >> /etc/opendevstack/config.json \
-    && echo "  \"sonarqubeEdition\": \"$SONAR_EDITION\"," >> /etc/opendevstack/config.json \
-    && echo "  \"sonarqubeVersion\": \"$SONAR_VERSION\"" >> /etc/opendevstack/config.json \
-    && echo "}" >> /etc/opendevstack/config.json
 
 # Install Tailor.
 RUN cd /tmp \

--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -15,10 +15,6 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 ARG APP_DNS=192.168.99.100.nip.io
 ARG APP_DNS_PORT=443
 ARG SNYK_DISTRIBUTION_URL
-ARG ODS_GIT_REF
-ARG ODS_IMAGE_TAG
-ARG SONAR_EDITION
-ARG SONAR_VERSION
 
 RUN yum -y install \
     gnutls-utils \
@@ -71,15 +67,6 @@ RUN cd /tmp \
     && mkdir /usr/local/cnes \
     && mv cnesreport.jar /usr/local/cnes/ \
     && chmod 777 /usr/local/cnes/cnesreport.jar
-
-# Add ODS configuration file.
-RUN mkdir -p /etc/opendevstack \
-    && echo "{" > /etc/opendevstack/config.json \
-    && echo "  \"odsGitRef\": \"$ODS_GIT_REF\"," >> /etc/opendevstack/config.json \
-    && echo "  \"odsImageTag\": \"$ODS_IMAGE_TAG\"," >> /etc/opendevstack/config.json \
-    && echo "  \"sonarqubeEdition\": \"$SONAR_EDITION\"," >> /etc/opendevstack/config.json \
-    && echo "  \"sonarqubeVersion\": \"$SONAR_VERSION\"" >> /etc/opendevstack/config.json \
-    && echo "}" >> /etc/opendevstack/config.json
 
 # Install Tailor.
 RUN cd /tmp \


### PR DESCRIPTION
* Moves the ODS configuration file from the slaves to the master.
* Uses the information in the config file to set the default branch of the global libraries (which removes yet another place which needs `production` to be present).
* Replaces existing libraries with the new configuration on boot so that any parameter changes are reflected.
* Cleanup of log messages.

As a next step, I'll read this configuration in the shared library, and place it into the context there. Then all stages have access to the information, which they can use e.g. to determine whether the PR analysis feature is turned on.