### PR TITLE
Add new target cd-project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ SHELL = /bin/bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
+# ODS SETUP
+## Setup central "cd" project.
+cd-project:
+	cd ods-setup && ./setup-ods-project.sh
+
 # CONFIG
 ## Update configuration based on sample config.
 config:

--- a/ods-setup/setup-jenkins-images.sh
+++ b/ods-setup/setup-jenkins-images.sh
@@ -10,7 +10,6 @@ function usage {
    printf "\t-h|--help\tPrints the usage\n"
    printf "\t-v|--verbose\tVerbose output\n"
    printf "\t-t|--tailor\tChanges the executable of tailor. Default: tailor\n"
-   printf "\t-n|--namespace\tChanges the default OpenDevStack namespace where all resources will be created. Default: cd\n"
    printf "\t-r|--ods-base-repository\tODS base repository. Overrides default in settings file\n"
    printf "\t-b|--ods-ref\tODS reference in repository. Overrides default in settings file\n"
 
@@ -29,9 +28,6 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 
    -t=*|--tailor=*) TAILOR="${1#*=}";;
    -t|--tailor) TAILOR="$2"; shift;;
-
-   -n=*|--namespace=*) NAMESPACE="${1#*=}";;
-   -n|--namespace) NAMESPACE="$2"; shift;;
 
    -r=*|--ods-base-repository=*) REPOSITORY="${1#*=}";;
    -r|--ods-base-repository) REPOSITORY="$2"; shift;;

--- a/ods-setup/setup-ods-project.sh
+++ b/ods-setup/setup-ods-project.sh
@@ -38,19 +38,17 @@ if ! oc whoami; then
   exit 1
 fi
 
+# Create namespace
 if oc project ${NAMESPACE}; then
   echo "The project '${NAMESPACE}' already exists"
-  exit 1
+else
+  echo "Creating project '${NAMESPACE}' ..."
+  oc new-project ${NAMESPACE} --description="Central ODS namespace with shared resources" --display-name="OpenDevStack"
 fi
-
-oc new-project ${NAMESPACE} --description="Base project holding the templates and the Repositoy Manager" --display-name="OpenDevStack"
 
 # Allow system:authenticated group to pull images from CD namespace
 oc adm policy add-cluster-role-to-group system:image-puller system:authenticated -n ${NAMESPACE}
 oc adm policy add-role-to-group view system:authenticated -n ${NAMESPACE}
 
-oc create sa deployment -n ${NAMESPACE}
-oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:${NAMESPACE}:deployment
-
-# create secrets for global cd_user
+# Create  global cd_user secret
 ${TAILOR} update ${FORCE} --context-dir=${BASH_SOURCE%/*}/ocp-config/cd-user --non-interactive

--- a/ods-setup/setup-ods-project.sh
+++ b/ods-setup/setup-ods-project.sh
@@ -10,7 +10,6 @@ function usage {
    printf "\t-h|--help\tPrints the usage\n"
    printf "\t-v|--verbose\tVerbose output\n"
    printf "\t-t|--tailor\tChanges the executable of tailor. Default: tailor\n"
-   printf "\t-n|--namespace\tChanges the default OpenDevStack namespace where all resources will be created. Default: cd\n"
 
 }
 TAILOR="tailor"
@@ -26,9 +25,6 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 
    -t=*|--tailor=*) TAILOR="${1#*=}";;
    -t|--tailor) TAILOR="$2"; shift;;
-
-   -n=*|--namespace=*) NAMESPACE="${1#*=}";;
-   -n|--namespace) NAMESPACE="$2"; shift;;
 
    *) echo "Unknown parameter passed: $1"; usage; exit 1;;
  esac; shift; done

--- a/tests/ods-setup/setup-ods-project_test.go
+++ b/tests/ods-setup/setup-ods-project_test.go
@@ -9,13 +9,11 @@ import (
 )
 
 func TestCreateOdsProject(t *testing.T) {
-	namespace := "ods"
+	namespace := "cd"
 	_ = utils.RemoveProject(namespace)
 	stdout, stderr, err := utils.RunScriptFromBaseDir("ods-setup/setup-ods-project.sh", []string{
 		"--force",
 		"--verbose",
-		"--namespace",
-		namespace,
 	}, []string{})
 	if err != nil {
 		t.Fatalf(
@@ -47,7 +45,6 @@ func TestCreateOdsProject(t *testing.T) {
 		"--verbose",
 		"--force",
 		"--ods-ref", gitReference,
-		"--namespace", namespace,
 	}, []string{})
 	if err != nil {
 		t.Fatalf(


### PR DESCRIPTION
* Exposes creation/setup of central project to ease installation
* Removes unnecessary deployment serviceaccount

Closes #414.

@hugowschneider I noticed that we can merge the scripts that you use in your tests with the makefile targets, but that needs to be a follow-up PR.