### PR TITLE
#419 update sonar-cnes-report to 3.1.0 on ods jenkins-slave-base

### DIFF
--- a/jenkins/slave-base/Dockerfile.centos7
+++ b/jenkins/slave-base/Dockerfile.centos7
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     OWASP_DEPENDENCY_CHECK_VERSION=3.2.1 \
-    CNES_REPORT_VERSION=2.0.0 \
+    CNES_REPORT_VERSION=3.1.0 \
     TAILOR_VERSION=0.11.0 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
@@ -63,9 +63,9 @@ ENV PATH=/usr/local/dependency-check-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/cnesreport.jar \
+    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar
     && mkdir /usr/local/cnes \
-    && mv cnesreport.jar /usr/local/cnes/ \
+    && mv sonar-cnes-report-${CNES_REPORT_VERSION}.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar
 
 # Install Tailor.

--- a/jenkins/slave-base/Dockerfile.centos7
+++ b/jenkins/slave-base/Dockerfile.centos7
@@ -63,7 +63,7 @@ ENV PATH=/usr/local/dependency-check-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar
+    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar \
     && mkdir /usr/local/cnes \
     && mv sonar-cnes-report-${CNES_REPORT_VERSION}.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar

--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -6,7 +6,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     OWASP_DEPENDENCY_CHECK_VERSION=3.2.1 \
-    CNES_REPORT_VERSION=2.0.0 \
+    CNES_REPORT_VERSION=3.1.0 \
     TAILOR_VERSION=0.11.0 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
@@ -63,9 +63,9 @@ ENV PATH=/usr/local/dependency-check-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/cnesreport.jar \
+    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar \
     && mkdir /usr/local/cnes \
-    && mv cnesreport.jar /usr/local/cnes/ \
+    && mv sonar-cnes-report-${CNES_REPORT_VERSION}.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar
 
 # Install Tailor.


### PR DESCRIPTION
Fix #419 updating sonar-cnes-report to 3.1.0.
With this change ODS now supports sonarQube 8.x