### PR TITLE
force name cnesreport.jar

### DIFF
--- a/jenkins/slave-base/Dockerfile.centos7
+++ b/jenkins/slave-base/Dockerfile.centos7
@@ -63,9 +63,9 @@ ENV PATH=/usr/local/dependency-check-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar \
+    && curl -Lv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar -o cnesreport.jar \
     && mkdir /usr/local/cnes \
-    && mv sonar-cnes-report-${CNES_REPORT_VERSION}.jar /usr/local/cnes/cnesreport.jar \
+    && mv cnesreport.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar
 
 # Install Tailor.

--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -63,9 +63,9 @@ ENV PATH=/usr/local/dependency-check-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -LOv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar \
+    && curl -Lv https://github.com/lequal/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar -o cnesreport.jar \
     && mkdir /usr/local/cnes \
-    && mv sonar-cnes-report-${CNES_REPORT_VERSION}.jar /usr/local/cnes/cnesreport.jar \
+    && mv cnesreport.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar
 
 # Install Tailor.


### PR DESCRIPTION
fix cnesreport.jar naming issue when building slave-base
relates #433 