### PR TITLE
Backport git scm plugin for 2.x branch

### DIFF
--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -59,6 +59,7 @@ ADD https://github.com/deepy/sonar-crowd/releases/download/2.1.3/sonar-crowd-plu
 ADD https://github.com/vaulttec/sonar-auth-oidc/releases/download/v1.1.0/sonar-auth-oidc-plugin-1.1.0.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/1.2.6/sonar-dependency-check-plugin-1.2.6.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/rht-labs/sonar-auth-openshift/releases/download/v1.1.1/sonar-auth-openshift-plugin.jar /opt/configuration/sonarqube/plugins/
+ADD https://binaries.sonarsource.com/Distribution/sonar-scm-git-plugin/sonar-scm-git-plugin-1.9.1.1834.jar /opt/configuration/sonarqube/plugins/
 # Language plugins
 ADD https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-6.2.0.21135.jar /opt/configuration/sonarqube/plugins/
 ADD https://binaries.sonarsource.com/Distribution/sonar-go-plugin/sonar-go-plugin-1.6.0.719.jar /opt/configuration/sonarqube/plugins/


### PR DESCRIPTION
Required for
https://github.com/opendevstack/ods-jenkins-shared-library/issues/174.

FYI @borja44 