### PR TITLE
Preserve immutable fields in Nexus/SonarQube config

### DIFF
--- a/nexus/ocp-config/Tailorfile
+++ b/nexus/ocp-config/Tailorfile
@@ -2,5 +2,6 @@ namespace cd
 selector  app=nexus3
 param-file ../../../ods-configuration/ods-core.env
 ignore-unknown-parameters true
+preserve-immutable-fields true
 
 dc,is,pvc,route,svc

--- a/sonarqube/ocp-config/Tailorfile
+++ b/sonarqube/ocp-config/Tailorfile
@@ -2,5 +2,6 @@ namespace cd
 selector app=sonarqube
 param-file ../../../ods-configuration/ods-core.env
 ignore-unknown-parameters true
+preserve-immutable-fields true
 
 bc,dc,is,pvc,route,svc,secret,configmap


### PR DESCRIPTION
E.g. if some config changed regarding PVCs, we do not want to destroy
the existsing PVC. Users may still choose to do that manually ...