### PR TITLE
ci build jenkins images: webhook-proxy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false ; trimming trailing whitespace may break Markdown
 
+[*.(yml|yaml)]
+indent_size = 2
+
 [Makefile]
 tab_width = 4
 indent_style = tab

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,6 +1,18 @@
 name: Continous Integration Tests
 on: [push, pull_request]
 jobs:
+  build-jenkins-images:
+    name: Build Jenkins docker images
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v2.0.0
+      -
+        name: docker build webhook-proxy
+        working-directory: jenkins/webhook-proxy
+        run: |
+          docker build -t webhook-proxy .
   webhook-proxy:
     name: Webhook Proxy tests
     runs-on: ubuntu-18.04


### PR DESCRIPTION
See https://github.com/opendevstack/ods-core/pull/455#issuecomment-609605649

However perhaps it would also make sense to have this on docker hub. For this I see a need to at least:

1. Figure out how to tag this?
2. Establish a docker Team or Organization for BI or BIX (see https://docs.docker.com/docker-hub/orgs/). 

Closes #157.
