### PR TITLE
Use latest version (1.0.44) of openshift-sync plugin

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -8,4 +8,4 @@ workflow-cps-global-lib:2.13
 junit:1.28
 blueocean:1.18.0
 workflow-durable-task-step:2.28
-openshift-sync:1.0.34
+openshift-sync:1.0.44


### PR DESCRIPTION
Closes #441.

I deleted the PVC of Jenkins and created new pipelines - `refspec` is not set as expected. That means 1.0.44 is correct.