### PR TITLE
Automate configuration of SonarQube

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -13,6 +13,19 @@ jobs:
         working-directory: jenkins/webhook-proxy
         run: |
           docker build -t webhook-proxy .
+
+  sonarqube:
+    name: SonarQube tests
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v2.0.0
+      -
+        name: Run tests
+        run: |
+          cd sonarqube && ./test.sh
+
   webhook-proxy:
     name: Webhook Proxy tests
     runs-on: ubuntu-18.04
@@ -43,6 +56,7 @@ jobs:
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           make -C jenkins/webhook-proxy test
+
   cluster:
     name: Setup and project provisioning tests
     runs-on: ubuntu-16.04

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ start-jenkins-build-webhook-proxy:
 
 # SONARQUBE
 ## Install or update SonarQube.
-install-sonarqube: apply-sonarqube-build start-sonarqube-build apply-sonarqube-deploy
+install-sonarqube: apply-sonarqube-build start-sonarqube-build apply-sonarqube-deploy configure-sonarqube
 .PHONY: install-sonarqube
 
 ## Update OpenShift resources related to the SonarQube image.
@@ -66,16 +66,22 @@ apply-sonarqube-build:
 	cd sonarqube/ocp-config && tailor apply bc,is
 .PHONY: apply-sonarqube-build
 
+## Start build of BuildConfig "sonarqube".
+start-sonarqube-build:
+	ocp-scripts/start-and-follow-build.sh --build-config sonarqube
+.PHONY: start-sonarqube-build
+
 ## Update OpenShift resources related to the SonarQube service.
 apply-sonarqube-deploy:
 	cd sonarqube/ocp-config && tailor apply --exclude bc,is
 	route=$(oc get route sonarqube -ojsonpath={.spec.host}) && echo "Visit ${route}/setup to see if any update actions need to be taken."
 .PHONY: apply-sonarqube-deploy
 
-## Start build of BuildConfig "sonarqube".
-start-sonarqube-build:
-	ocp-scripts/start-and-follow-build.sh --build-config sonarqube
-.PHONY: start-sonarqube-build
+## Configure SonarQube service.
+configure-sonarqube:
+	route=$(oc get route sonarqube -ojsonpath={.spec.host})
+	cd sonarqube && ./configure.sh --sonarqube=${route}
+.PHONY: configure-sonarqube
 
 # NEXUS
 ## Install or update Nexus.

--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -137,12 +137,9 @@ In `ods-core` run:
 make install-sonarqube
 ----
 
-Afterwards, perform the following manual steps:
-
-. Change admin password
-. Lock SonarQube to logged-in users (Administation > Configuration > Security > Force User Authentication).
-. Log in as `cd_user` and created an auth token (My Account > Security > Generate New Token).
-. As the auth token and the admin password have changed, update your OpenShift configuration repository and the `sonarqube-app` secret.
+This will launch an instance of SonarQube.
+The script will prompt for a new admin password, set it and create an auth token to be used by the Jenkins pipelines.
+At the end, the script will ask you to adjust `ods-configuration/ods-core.env`, which you need to commit and push before continuing.
 
 === Jenkins
 

--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -1,9 +1,14 @@
 FROM adoptopenjdk/openjdk11:alpine-jre
 
+ARG sonarDistributionUrl
+ARG sonarVersion
+ARG idpDns
+
 ENV SONARQUBE_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
     SONARQUBE_JDBC_PASSWORD=sonar \
-    SONARQUBE_JDBC_URL=
+    SONARQUBE_JDBC_URL= \
+    SONAR_VERSION=${sonarVersion}
 
 # Http port
 EXPOSE 9000
@@ -20,7 +25,7 @@ RUN set -x \
     && apk add --no-cache bash \
     && mkdir -p /opt \
     && cd /opt \
-    && wget -O sonarqube.zip --no-verbose $SONAR_DISTRIBUTION_URL \
+    && wget -O sonarqube.zip --no-verbose $sonarDistributionUrl \
     && unzip sonarqube.zip \
     && mv sonarqube-$SONAR_VERSION sonarqube \
     && chown -R sonarqube:root sonarqube \
@@ -31,9 +36,9 @@ RUN set -x \
     && chown -R sonarqube:root /opt/configuration/sonarqube
 
 # fetch certificates and store them in tmp directory
-RUN if [ -z $IDP_DNS ]; then echo 'Skipping custom certificate!'; else \
-    echo "Setting up custom certificate from ${IDP_DNS} ..."; \
-    gnutls-cli --insecure --print-cert ${IDP_DNS} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/idp.crt; \
+RUN if [ -z $idpDns ]; then echo 'Skipping custom certificate!'; else \
+    echo "Setting up custom certificate from ${idpDns} ..."; \
+    gnutls-cli --insecure --print-cert ${idpDns} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/idp.crt; \
     cat /tmp/idp.crt|awk 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1} {print > "/usr/local/share/ca-certificates/mycert" n ".crt"}'; \
     update-ca-certificates; \
     keytool -importcert -keypass changeit -file /tmp/idp.crt -keystore $JAVA_HOME/lib/security/cacerts -noprompt -storepass changeit; \
@@ -51,7 +56,6 @@ RUN mkdir -p /opt/configuration/sonarqube/plugins
 ADD https://github.com/deepy/sonar-crowd/releases/download/2.1.3/sonar-crowd-plugin-2.1.3.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/vaulttec/sonar-auth-oidc/releases/download/v1.1.0/sonar-auth-oidc-plugin-1.1.0.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/dependency-check/dependency-check-sonar-plugin/releases/download/1.2.6/sonar-dependency-check-plugin-1.2.6.jar /opt/configuration/sonarqube/plugins/
-ADD https://github.com/rht-labs/sonar-auth-openshift/releases/download/v1.1.1/sonar-auth-openshift-plugin.jar /opt/configuration/sonarqube/plugins/
 ADD https://binaries.sonarsource.com/Distribution/sonar-scm-git-plugin/sonar-scm-git-plugin-1.9.1.1834.jar /opt/configuration/sonarqube/plugins/
 # Language plugins
 ADD https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-6.2.0.21135.jar /opt/configuration/sonarqube/plugins/

--- a/sonarqube/configure.sh
+++ b/sonarqube/configure.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -ue
+
+echo_done(){
+    echo -e "\033[92mDONE\033[39m: $1"
+}
+
+echo_warn(){
+    echo -e "\033[93mWARN\033[39m: $1"
+}
+
+echo_error(){
+    echo -e "\033[31mERROR\033[39m: $1"
+}
+
+echo_info(){
+    echo -e "\033[94mINFO\033[39m: $1"
+}
+
+ADMIN_USER_NAME=admin
+ADMIN_USER_DEFAULT_PASSWORD=admin
+ADMIN_USER_PASSWORD=
+PIPELINE_USER_NAME=cd_user
+PIPELINE_USER_PWD=
+TOKEN_NAME=ods-jenkins-shared-library
+SONARQUBE_URL=
+
+function usage {
+    printf "Setup SonarQube.\n\n"
+    printf "This script will ask interactively for parameters by default.\n"
+    printf "However, you can also pass them directly. Usage:\n\n"
+    printf "\t-h|--help\t\tPrint usage\n"
+    printf "\t-v|--verbose\t\tEnable verbose mode\n"
+    printf "\t-s|--sonarqube\t\tSonarQube URL, e.g. 'https://bitbucket.sonarqube.com'\n"
+    printf "\t-a|--admin-password\t\tAdmin password\n"
+    printf "\t-p|--pipeline-user\tName of Jenkins pipeline user (defaults to 'cd_user')\n"
+    printf "\t-t|--token-name\t\tName of SonarQube user token (defaults to 'ods-jenkins-shared-library')\n"
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    -v|--verbose) set -x;;
+
+    -h|--help) usage; exit 0;;
+
+    -a|--admin-password) ADMIN_USER_PASSWORD="$2"; shift;;
+    -a=*|--admin-password=*) ADMIN_USER_PASSWORD="${1#*=}";;
+
+    -p|--pipeline-user) PIPELINE_USER_NAME="$2"; shift;;
+    -p=*|--pipeline-user=*) PIPELINE_USER_NAME="${1#*=}";;
+
+    -t|--token-name) TOKEN_NAME="$2"; shift;;
+    -t=*|--token-name=*) TOKEN_NAME="${1#*=}";;
+
+    -s|--sonarqube) SONARQUBE_URL="$2"; shift;;
+    -s=*|--sonarqube=*) SONARQUBE_URL="${1#*=}";;
+
+    *) echo_error "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+if ! which jq >/dev/null; then
+    echo_warn "Binary 'jq' (https://stedolan.github.io/jq/) is not in your PATH. This will make the script less comfortable to use."
+    read -e -p "Continue anyway? [y/n] " input
+    if [ "${input:-""}" != "y" ]; then
+        exit 1
+    fi
+fi
+
+if [ -z ${SONARQUBE_URL} ]; then
+    read -e -p "Enter SonarQube URL (e.g. https://example.sonarqube.com): " input
+    SONARQUBE_URL=${input:-""}
+fi
+
+if [ -z ${ADMIN_USER_PASSWORD} ]; then
+    echo "Please enter SonarQube admin password:"
+    read -e -s input
+    ADMIN_USER_PASSWORD=${input:-""}
+fi
+
+echo_info "Checking if '${ADMIN_USER_NAME}' uses default password '${ADMIN_USER_DEFAULT_PASSWORD}'"
+if curl -X POST --fail --silent \
+    "${SONARQUBE_URL}/api/authentication/login?login=${ADMIN_USER_NAME}&password=${ADMIN_USER_DEFAULT_PASSWORD}"; then
+    echo_info "Default password '${ADMIN_USER_DEFAULT_PASSWORD}' is used, updating it now."
+    if ! curl -X POST --fail --silent --user ${ADMIN_USER_NAME}:${ADMIN_USER_NAME} \
+        "${SONARQUBE_URL}/api/users/change_password?login=${ADMIN_USER_NAME}&password=${ADMIN_USER_PASSWORD}&previousPassword=${ADMIN_USER_DEFAULT_PASSWORD}"; then
+        echo_error "Could not change default password of '${ADMIN_USER_NAME}'."
+        exit 1
+    fi
+    base64Password=$(echo -n $ADMIN_USER_PASSWORD | base64)
+    echo_info "Base64-encoded password to use for 'SONAR_ADMIN_PASSWORD_B64': ${base64Password}"
+    echo_info "Default password changed"
+else
+    echo_info "Default password is not in use."
+fi
+
+echo_info "Setting sonar.forceAuthentication=true"
+if ! curl -X POST --fail --silent --user ${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD} \
+    "${SONARQUBE_URL}/api/settings/set?key=sonar.forceAuthentication&value=true"; then
+    echo_error "Could not enable sonar.forceAuthentication."
+    exit 1
+fi
+echo_info "sonar.forceAuthentication is enabled"
+
+echo_info "Checking if '${PIPELINE_USER_NAME}' exists"
+if curl -X POST --fail --silent --user ${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD} \
+    "${SONARQUBE_URL}/api/users/search?q=${PIPELINE_USER_NAME}" | grep '"users":\[\]' >/dev/null; then
+    echo_info "No user '${PIPELINE_USER_NAME}' present yet."
+    if [ -z ${PIPELINE_USER_PWD} ]; then
+        echo "Please enter '${PIPELINE_USER_NAME}' password:"
+        read -e -s input
+        PIPELINE_USER_PWD=${input:-""}
+    fi
+    echo_info "Trying to login in with '${PIPELINE_USER_NAME}'"
+    if ! curl -X POST --fail --silent \
+        "${SONARQUBE_URL}/api/authentication/login?login=${PIPELINE_USER_NAME}?password=${PIPELINE_USER_PWD}"; then
+        echo_error "Could not login with '${PIPELINE_USER_NAME}'."
+        exit 1
+    fi
+    echo_info "User token created"
+fi
+echo_info "User '${PIPELINE_USER_NAME}' exists in SonarQube"
+
+echo_info "Checking if there are already tokens for '${PIPELINE_USER_NAME}'"
+if ! curl --fail --silent --user ${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD} \
+    "${SONARQUBE_URL}/api/user_tokens/search?login=${PIPELINE_USER_NAME}" | grep '"userTokens":\[\]' >/dev/null; then
+    echo_info "There are already token(s) for '${PIPELINE_USER_NAME}'."
+else
+    echo_info "Creating token for '${PIPELINE_USER_NAME}'."
+    tokenResponse=$(curl -X POST --fail --silent --user ${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD} \
+        "${SONARQUBE_URL}/api/user_tokens/generate?login=${PIPELINE_USER_NAME}&name=${TOKEN_NAME}")
+    # Example response:
+    # {"login":"cd_user","name":"foo","token":"bar","createdAt":"2020-04-22T13:21:54+0000"}
+    if which jq >/dev/null; then
+        token=$(echo $tokenResponse | jq -r .token)
+        echo_info "Created token: ${token}"
+        base64Token=$(echo -n $token | base64)
+        echo_info "Base64-encoded token to use for 'SONAR_AUTH_TOKEN_B64': ${base64Token}"
+    else
+        echo_info "Created token! Response: ${tokenResponse}"
+    fi
+fi
+
+echo "If configuration needs to be updated, please add the base64 encoded token and the admin password into ods-core.env."
+
+echo_done "SonarQube configured"

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -29,12 +29,12 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
-        env:
-          - name: SONAR_VERSION
+        buildArgs:
+          - name: sonarVersion
             value: ${SONAR_VERSION}
-          - name: SONAR_DISTRIBUTION_URL
+          - name: sonarDistributionUrl
             value: ${SONAR_DISTRIBUTION_URL}
-          - name: IDP_DNS
+          - name: idpDns
             value: ${IDP_DNS}
       type: Docker
     successfulBuildsHistoryLimit: 5

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -1,0 +1,107 @@
+
+#!/usr/bin/env bash
+set -ue
+
+SONAR_VERSION=7.9
+SONAR_DISTRIBUTION_URL=https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-7.9.zip
+
+echo "Build image"
+docker build \
+    -t sqtest \
+    --build-arg sonarDistributionUrl=${SONAR_DISTRIBUTION_URL} \
+    --build-arg sonarVersion=${SONAR_VERSION} \
+    --build-arg idpDns="" \
+    .
+
+echo "Run container"
+containerId=$(docker run -d --stop-timeout 3600 -d -p 9001:9000 -p 9093:9092 sqtest)
+
+function cleanup {
+    echo "Cleanup"
+    docker rm -f ${containerId}
+}
+trap cleanup EXIT
+
+SONARQUBE_URL="http://localhost:9001"
+ADMIN_USER_NAME=admin
+ADMIN_USER_DEFAULT_PASSWORD=admin
+ADMIN_USER_PWD=s3cr3t
+PIPELINE_USER_NAME=cd_user
+PIPELINE_USER_PWD=cd_user
+
+echo "Wait for SonarQube to become healthy"
+set +e
+n=0
+until [ $n -ge 20 ]; do
+    health=$(curl --silent --user ${ADMIN_USER_NAME}:${ADMIN_USER_DEFAULT_PASSWORD} \
+        "${SONARQUBE_URL}/api/system/health" | jq -r .health)
+    if [ "${health}" == "GREEN" ]; then
+        echo "SonarQube is up"
+        break
+    else
+        echo "SonarQube is not up yet, waiting 10s ..."
+        sleep 10s
+        n=$[$n+1]
+    fi
+done
+set -e
+
+echo "Create fake cd_user"
+curl -X POST --silent --fail --user ${ADMIN_USER_NAME}:${ADMIN_USER_DEFAULT_PASSWORD} \
+    "${SONARQUBE_URL}/api/users/create?login=${PIPELINE_USER_NAME}&name=${PIPELINE_USER_NAME}&local=true&password=${PIPELINE_USER_PWD}" > /dev/null
+
+echo "Run ./configure.sh"
+./configure.sh \
+    --admin-password=s3cr3t \
+    --pipeline-user=${PIPELINE_USER_NAME} \
+    --sonarqube=${SONARQUBE_URL}
+
+echo "Check if login with default password is possible"
+if curl -X POST --silent --fail \
+    "${SONARQUBE_URL}/api/authentication/login?login=${ADMIN_USER_NAME}&password=${ADMIN_USER_DEFAULT_PASSWORD}"; then
+    echo "Default password for '${ADMIN_USER_NAME}' has not been changed"
+    exit 1
+fi
+
+echo "Check if unauthenticated access is possible"
+forceAuthentication=$(curl \
+    --silent \
+    --user ${ADMIN_USER_NAME}:${ADMIN_USER_PWD} \
+    "${SONARQUBE_URL}/api/settings/values?keys=sonar.forceAuthentication" | jq -r ".settings[0].value")
+if [ "${forceAuthentication}" != "true" ]; then
+    echo "sonar.forceAuthentication is not enabled"
+    exit 1
+fi
+
+echo "Check if plugins are installed in correct versions"
+expectedPlugins=( "crowd:2.1.3"
+                  "authoidc:1.1.0"
+                  "dependencycheck:1.2.6"
+                  "scmgit:1.9.1.1834"
+                  "java:6.2.0.21135"
+                  "jacoco:1.0.2.475"
+                  "go:1.6.0.719"
+                  "javascript:6.1.0.11503"
+                  "python:2.1.0.5269"
+                  "typescript:2.1.0.4359"
+                  "sonarscala:1.5.0.315" )
+
+actualPlugins=$(curl \
+    --fail \
+    --silent \
+    --user ${ADMIN_USER_NAME}:${ADMIN_USER_PWD} \
+    "${SONARQUBE_URL}/api/system/info" | jq '.Statistics.plugins')
+
+for plugin in "${expectedPlugins[@]}"; do
+    pluginName=${plugin%%:*}
+    pluginVersion=${plugin#*:}
+    actualVersion=$(echo ${actualPlugins} | jq -r ".[] | select(.name == \"${pluginName}\") | .version")
+    if [ "${actualVersion}" == "${pluginVersion}" ]; then
+        echo "Plugin ${pluginName} has expected version ${pluginVersion}"
+    else
+        echo "Wrong ${pluginName} plugin version, want: ${pluginVersion}, got: ${actualVersion}"
+        exit 1
+    fi
+done
+
+echo "Success"


### PR DESCRIPTION
1. Change admin password
2. Lock SonarQube to logged-in users (Administation > Configuration > Security > Force User Authentication).
3. Log in as `cd_user` and create an auth token (My Account > Security > Generate New Token).

Futher, this PR adds tests:
* Build image
* Run container
* Execute config script
* Check configuration and plugins

It also removes the plugin `sonar-auth-openshift-plugin`, which was introduced in https://github.com/opendevstack/ods-core/pull/255. Right now this is not used. It was added to support further work on SSO via OpenShift. Unfortunately, the plugin caused problems when I tried to run the container outside OpenShift. When we need the plugin in the future, we can add it back in and adjust the tests to work with it (e.g. installing it only conditionally, or configuring it properly ...)

Closes #488.