### PR TITLE
Allow group to write to /home/jenkins/.cache

### DIFF
--- a/jenkins/slave-base/Dockerfile.centos7
+++ b/jenkins/slave-base/Dockerfile.centos7
@@ -111,4 +111,5 @@ RUN yum install -y \
     && skopeo --version
 
 # Fix permissions.
-RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config
+RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config \
+    && mkdir -p /home/jenkins/.cache && chmod g+w /home/jenkins/.cache

--- a/jenkins/slave-base/Dockerfile.rhel7
+++ b/jenkins/slave-base/Dockerfile.rhel7
@@ -111,4 +111,5 @@ RUN yum install -y \
     && skopeo --version
 
 # Fix permissions.
-RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config
+RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config \
+    && mkdir -p /home/jenkins/.cache && chmod g+w /home/jenkins/.cache


### PR DESCRIPTION
Also a typical directory to write to, e.g. used by Go tools.

Basically the same as #480.

Closes #496.