### PR TITLE
Revert "change service-ca import to runtime for sonarcube and jenkins"

### DIFF
--- a/jenkins/master/Dockerfile
+++ b/jenkins/master/Dockerfile
@@ -14,6 +14,10 @@ RUN yum -y install openssl gnutls-utils \
     && yum clean all  \
     && rm -rf /var/cache/yum/*
 
+# Fetch certificates and store them in tmp directory.
+COPY ./import_certs.sh /usr/local/bin/import_certs.sh
+RUN import_certs.sh
+
 # Copy configuration and plugins.
 COPY plugins.txt /opt/openshift/configuration/plugins.txt
 COPY kube-slave-common.sh /usr/local/bin/kube-slave-common.sh
@@ -31,8 +35,6 @@ RUN mkdir -p /etc/opendevstack \
     && echo "  \"sonarqubeEdition\": \"$SONAR_EDITION\"," >> /etc/opendevstack/config.json \
     && echo "  \"sonarqubeVersion\": \"$SONAR_VERSION\"" >> /etc/opendevstack/config.json \
     && echo "}" >> /etc/opendevstack/config.json
-
-RUN chmod g+w /opt/java/openjdk/lib/security/cacerts
 
 USER jenkins
 ENV JENKINS_JAVA_OVERRIDES="-Dhudson.tasks.MailSender.SEND_TO_UNKNOWN_USERS=true -Dhudson.tasks.MailSender.SEND_TO_USERS_WITHOUT_READ=true"

--- a/jenkins/master/import_certs.sh
+++ b/jenkins/master/import_certs.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+oldIFS=$IFS
+IFS=';'
+KEYSTORE="$JAVA_HOME/lib/security/cacerts"
+
+: "${APP_DNS_PORT:=443}"
+
+if [ "${TARGET_HOSTS}x" == "x" ] ; then
+    TARGET_HOSTS=${APP_DNS}
+fi
+
+echo "KEYSTORE=${KEYSTORE}"
+for dns in $TARGET_HOSTS; do
+    cert_bundle_path="/etc/pki/ca-trust/source/anchors/${dns}.pem"
+    gnutls-cli --insecure --print-cert ${dns} -p ${APP_DNS_PORT} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | tee ${cert_bundle_path}    
+    $JAVA_HOME/bin/keytool -import -noprompt -trustcacerts -file ${cert_bundle_path} -alias ${dns} -keystore ${KEYSTORE} -storepass changeit || true
+done
+update-ca-trust
+IFS=$oldIFS
+
+

--- a/jenkins/master/ods-run
+++ b/jenkins/master/ods-run
@@ -4,17 +4,6 @@
 # then delegates to the original run script of the base image.
 set -ue
 
-# Openshift default CA. See https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
-SERVICEACCOUNT_CA='/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
-if [[ -f $SERVICEACCOUNT_CA ]]; then
-  echo "INFO: found $SERVICEACCOUNT_CA"
-  echo "INFO: importing into cacerts"
-  keytool -importcert -v -trustcacerts -alias service-ca -keystore "$JAVA_HOME"/lib/security/cacerts -storepass changeit -file "$SERVICEACCOUNT_CA" -noprompt
-else
-  echo "INFO: could not find '$SERVICEACCOUNT_CA'"
-  echo "INFO: skip import"
-fi
-
 echo "Booting Jenkins ..."
 
 target_init_groovy_dir="${JENKINS_HOME}/init.groovy.d"

--- a/sonarqube/Dockerfile
+++ b/sonarqube/Dockerfile
@@ -2,6 +2,7 @@ FROM adoptopenjdk/openjdk11:alpine-jre
 
 ARG sonarDistributionUrl
 ARG sonarVersion
+ARG idpDns
 
 ENV SONARQUBE_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
@@ -34,6 +35,15 @@ RUN set -x \
     && mkdir -p /opt/configuration/sonarqube \
     && chown -R sonarqube:root /opt/configuration/sonarqube
 
+# fetch certificates and store them in tmp directory
+RUN if [ -z $idpDns ]; then echo 'Skipping custom certificate!'; else \
+    echo "Setting up custom certificate from ${idpDns} ..."; \
+    gnutls-cli --insecure --print-cert ${idpDns} </dev/null| sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/idp.crt; \
+    cat /tmp/idp.crt|awk 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1} {print > "/usr/local/share/ca-certificates/mycert" n ".crt"}'; \
+    update-ca-certificates; \
+    keytool -importcert -keypass changeit -file /tmp/idp.crt -keystore $JAVA_HOME/lib/security/cacerts -noprompt -storepass changeit; \
+    fi
+
 VOLUME "$SONARQUBE_HOME/data"
 
 WORKDIR $SONARQUBE_HOME
@@ -59,7 +69,6 @@ ADD https://binaries.sonarsource.com/Distribution/sonar-php-plugin/sonar-php-plu
 RUN chown -R :0 /opt/configuration/sonarqube/plugins; \
     chmod -R g=u /opt/configuration/sonarqube/plugins; \
     chown -R :0 $SONARQUBE_HOME/bin; \
-    chmod g+w /opt/java/openjdk/lib/security/cacerts; \
     chmod -R g+x $SONARQUBE_HOME/bin/run.sh
 
 USER sonarqube

--- a/sonarqube/run.sh
+++ b/sonarqube/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -21,17 +21,6 @@ for FILENAME in /opt/configuration/sonarqube/plugins/*; do
   plugin=$(basename "${FILENAME}")
   cp "${FILENAME}" "${SONARQUBE_HOME}/extensions/plugins/${plugin}"
 done
-
-# Openshift default CA. See https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
-SERVICEACCOUNT_CA='/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
-if [[ -f $SERVICEACCOUNT_CA ]]; then
-  echo "INFO: found $SERVICEACCOUNT_CA"
-  echo "INFO: importing into cacerts"
-  keytool -importcert -v -trustcacerts -alias service-ca -keystore "$JAVA_HOME"/lib/security/cacerts -storepass changeit -file "$SERVICEACCOUNT_CA" -noprompt
-else
-  echo "INFO: could not find '$SERVICEACCOUNT_CA'"
-  echo "INFO: skip import"
-fi
 
 exec java -jar "lib/sonar-application-${SONAR_VERSION}.jar" \
   -Dsonar.log.console=true \


### PR DESCRIPTION
Reverts opendevstack/ods-core#564.

Throws this error:
```
RUN chmod g+w /opt/java/openjdk/lib/security/cacerts
kommt der Fehler
chmod: cannot access ‘/opt/java/openjdk/lib/security/cacerts’: No such file or directory
Removing intermediate container c7fbd5e6e140
error: build error: The command '/bin/sh -c chmod g+w /opt/java/openjdk/lib/security/cacerts' returned a non-zero code: 1
```

FYI @georgfedermann 