### PR TITLE
Allow repo sync script to work with different target ref

### DIFF
--- a/ods-setup/repos.sh
+++ b/ods-setup/repos.sh
@@ -201,14 +201,13 @@ for REPO in ods-core ods-quickstarters ods-jenkins-shared-library ods-provisioni
   else
     echo_info "Creating local ref '${GIT_REF}'."
     git checkout -b ${GIT_REF} ods/${GIT_REF} --no-track
-    git branch --set-upstream-to origin/${GIT_REF}
   fi
   echo_done "Prepared ${REPO}."
 
   # Push to Bitbucket
   if [ "$SYNC" == "y" ]; then
     echo_info "Pushing '${GIT_REF}' to Bitbucket."
-    git push origin ${GIT_REF}
+    git push -u origin ${GIT_REF}
     echo_done "Pushed '${GIT_REF}' to Bitbucket."
   fi
 


### PR DESCRIPTION
For advanced users, who want to have a branch not named after one of the
official branches, this allows to use one branch as the source (e.g.
`3.x`) and merge/push that to a different target (e.g. `3.acme`).

It allows to have customisations in `3.acme`, while still updating with
the base branch (`3.x`).

This is intentionally not exposed in the `Makefile`.