### PR TITLE
BuildConfig resources

### DIFF
--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -48,7 +48,13 @@ objects:
         kind: ImageStreamTag
         name: 'jenkins-master:${ODS_IMAGE_TAG}'
     postCommit: {}
-    resources: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: "2Gi"
+      requests:
+        cpu: "200m"
+        memory: "1Gi"
     runPolicy: Serial
     source:
       type: Git
@@ -95,7 +101,13 @@ objects:
         kind: ImageStreamTag
         name: 'jenkins-slave-base:${ODS_IMAGE_TAG}'
     postCommit: {}
-    resources: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: "2Gi"
+      requests:
+        cpu: "200m"
+        memory: "1Gi"
     runPolicy: Serial
     source:
       contextDir: jenkins/slave-base
@@ -134,7 +146,13 @@ objects:
         kind: ImageStreamTag
         name: 'jenkins-webhook-proxy:${ODS_IMAGE_TAG}'
     postCommit: {}
-    resources: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: "1Gi"
+      requests:
+        cpu: "200m"
+        memory: "512Mi"
     runPolicy: Serial
     source:
       contextDir: jenkins/webhook-proxy

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -88,7 +88,13 @@ objects:
         kind: ImageStreamTag
         name: sonarqube:${ODS_IMAGE_TAG}
     postCommit: {}
-    resources: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: "2Gi"
+      requests:
+        cpu: "200m"
+        memory: "1Gi"
     runPolicy: Serial
     source:
       contextDir: sonarqube


### PR DESCRIPTION
Better to control the resources that are available than being at the mercy of the cluster defaults :)

Follow-up coming for quickstarters, which is where this change originated from.

Verified that I can build from master using those settings.