### PR TITLE
changes params in prov app pvc to optional to enable default storage

### DIFF
--- a/nexus/ocp-config/pvc.yml
+++ b/nexus/ocp-config/pvc.yml
@@ -5,10 +5,13 @@ parameters:
   value: nexus
 - name: STORAGE_PROVISIONER
   description: storage class provisioner. For AWS this could be kubernetes.io/aws-ebs. Leave empty for local (e.g. vagrant) deployments
+  value: ""
 - name: STORAGE_CLASS_DATA
   description: storage class for data. For AWS this could be gp2. Leave empty for local (e.g. vagrant) deployments
+  value: ""
 - name: STORAGE_CLASS_BACKUP
   description: Storage class for data backup. For AWS this could be gp2-encrypted. Leave empty for local (e.g. vagrant) deployments
+  value: ""
 - name: NEXUS_DATA_CAPACITY
   value: 60Gi
 - name: NEXUS_BACKUP_CAPACITY

--- a/ods-provisioning-app/ocp-config/pvc.yml
+++ b/ods-provisioning-app/ocp-config/pvc.yml
@@ -20,8 +20,8 @@ objects:
         storage: 10Mi
 parameters:
 - name: STORAGE_PROVISIONER
-  required: false
+  description: storage class provisioner. For AWS this could be kubernetes.io/aws-ebs. Leave empty for local (e.g. vagrant) deployments
+  value: ""
 - name: STORAGE_CLASS_DATA
-  required: false
-- name: STORAGE_CLASS_BACKUP
-  required: false
+  description: storage class for data. For AWS this could be gp2. Leave empty for local (e.g. vagrant) deployments
+  value: ""

--- a/ods-provisioning-app/ocp-config/pvc.yml
+++ b/ods-provisioning-app/ocp-config/pvc.yml
@@ -20,8 +20,8 @@ objects:
         storage: 10Mi
 parameters:
 - name: STORAGE_PROVISIONER
-  required: true
+  required: false
 - name: STORAGE_CLASS_DATA
-  required: true
+  required: false
 - name: STORAGE_CLASS_BACKUP
-  required: true
+  required: false


### PR DESCRIPTION
this fixes broken pvc deployment with tailor. Problem is that when paramerters are set with option `required: true` then Tailor doesn't accept empty values. For ods-devenv we need default values which are normaly set as `empty`.