### PR TITLE
Fix "java.lang.UnsupportedOperationException" during init script

### DIFF
--- a/jenkins/master/ods-run
+++ b/jenkins/master/ods-run
@@ -28,6 +28,8 @@ if [ -d "$target_init_groovy_dir" ] ; then
         echo "---> Copying ${source_init_groovy_dir}/${fileName} to ${target_init_groovy_dir}/${fileName} ..."
         cp "${source_init_groovy_dir}/${fileName}" "${target_init_groovy_dir}/${fileName}"
     done
+    echo "Remove legacy init.groovy.d files ..."
+    rm "${target_init_groovy_dir}/ods-mro-jenkins-shared-library.groovy" || true
 fi
 
 NEXUS_SHORT=$(echo $NEXUS_HOST | sed -e "s|https://||g" | sed -e "s|http://||g") 


### PR DESCRIPTION
Fixes #552.

The cause of `java.lang.UnsupportedOperationException` should be that the returned list is immutable, so new libraries cannot be added to it.

I couldn't quite figure out why it sometimes worked using the previous code. However the code now works if the list is mutable or not.

Also, as the `init.groovy.d` files are on the PVC, I added cleanup for the MRO loading, otherwise it always tries to clone that (obsolete) repo even if that might be removed from Bitbucket.

FYI @SimonGolms