### PR TITLE
removes clone-script involvement in credential handling

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -143,6 +143,7 @@ jobs:
       -
         name: Check compliant shell scripts
         run: |
+          shellcheck --version
           shellcheck ocp-scripts/clone-project.sh
           shellcheck ocp-scripts/verify-jsl-expectations.sh
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -129,6 +129,23 @@ jobs:
         run: |
           ./run.sh
 
+  clone-check:
+    name: verify clone script requirements
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v2.0.0
+      -
+        name: Check jsl expectations
+        run: |
+          ocp-scripts/verify-jsl-expectations.sh
+      -
+        name: Check compliant shell scripts
+        run: |
+          shellcheck ocp-scripts/clone-project.sh
+          shellcheck ocp-scripts/verify-jsl-expectations.sh
+
 # cluster:
 #   name: Setup and project provisioning tests
 #   runs-on: ubuntu-16.04

--- a/ocp-scripts/clone-project.sh
+++ b/ocp-scripts/clone-project.sh
@@ -113,7 +113,7 @@ echo "[INFO]: import resources into $TARGET_ENV"
 sh "$SCRIPT_DIR/import-project.sh" -h "$OPENSHIFT_HOST" -p "$PROJECT_ID" -e "$SOURCE_ENV" -g "$git_url" -gb "$GIT_BRANCH" -n "$TARGET_PROJECT" "$verbose" --apply true
 
 echo "[INFO]: cleanup workplace"
-# shellcheck disable=SC2124
+# shellcheck disable=SC2103
 cd ..
 rm -rf oc_migration_scripts
 

--- a/ocp-scripts/clone-project.sh
+++ b/ocp-scripts/clone-project.sh
@@ -7,9 +7,9 @@ usage() {
 for bitbucket host> -t <target env to clone to> -s <source env to clone from>";
 }
 
-ODS_BITBUCKET_PROJECT=opendevstack
+export ODS_BITBUCKET_PROJECT=opendevstack
 
-while [[ "$#" > 0 ]]; do case $1 in
+while [[ "$#" -gt 0 ]]; do case $1 in
   -o=*|--openshift-host=*) OPENSHIFT_HOST="${1#*=}";;
   -o|--openshift-host) OPENSHIFT_HOST="$2"; shift;;
 
@@ -18,9 +18,6 @@ while [[ "$#" > 0 ]]; do case $1 in
 
   --ods-bitbucket-project=*) ODS_BITBUCKET_PROJECT="${1#*=}";;
   --ods-bitbucket-project) ODS_BITBUCKET_PROJECT="$2"; shift;;
-
-  -c=*|--credentials=*) CREDENTIALS="${1#*=}";;
-  -c|--credentials) CREDENTIALS="$2"; shift;;
 
   -p=*|--project-id=*) PROJECT_ID="${1#*=}";;
   -p|--project-id) PROJECT_ID="$2"; shift;;
@@ -38,13 +35,7 @@ while [[ "$#" > 0 ]]; do case $1 in
   -gb=*|--git-branch=*) GIT_BRANCH="${1#*=}";;
   -gb|--git-branch) GIT_BRANCH="$2"; shift;;
 
-  -st|--skip-tag) SKIP_TAGS="true"; shift;;
-
-  -gb=*|--git-branch=*) GIT_BRANCH="${1#*=}";;
-  -gb|--git-branch) GIT_BRANCH="$2"; shift;;
-
-  -sb=*|--script-branch=*) SCRIPT_BRANCH="${1#*=}";;
-  -sb|--script-branch) SCRIPT_BRANCH="$2"; shift;;
+  --skip-tag) SKIP_TAGS="true"; shift;;
 
   *) echo "Unknown parameter passed: $1"; usage; exit 1;;
 esac; shift; done
@@ -56,11 +47,6 @@ if [[ -z "$PROJECT_ID" ]]; then
 fi
 if [[ -z "$BITBUCKET_HOST" ]]; then
     echo "[ERROR]: No BitBucket host set - required value"
-    usage
-    exit 1
-fi
-if [[ -z "$CREDENTIALS" ]]; then
-    echo "[ERROR]: No BitBucket credentials set - required value"
     usage
     exit 1
 fi
@@ -85,16 +71,10 @@ if [[ -z "$GIT_BRANCH" ]]; then
     GIT_BRANCH=master
 fi
 
-if [[ -z "$SCRIPT_BRANCH" ]]; then
-    echo "[DEBUG]: no script branch set - defaulting to master"
-    SCRIPT_BRANCH=master
-fi
-
 echo "Provided params: \
 - PROJECT_ID: $PROJECT_ID \
 - OPENSHIFT_HOST: $OPENSHIFT_HOST \
 - BITBUCKET_HOST: $BITBUCKET_HOST \
-- CREDENTIALS: ******** \
 - SOURCE_ENV: $SOURCE_ENV \
 - TARGET_ENV: $TARGET_ENV"
 
@@ -104,28 +84,8 @@ TARGET_PROJECT="$PROJECT_ID-$TARGET_ENV"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo "[INFO]: creating workplace: mkdir -p oc_migration_scripts/migration_config"
 mkdir -p oc_migration_scripts/migration_config
-cd oc_migration_scripts
-echo $(pwd)
-# The curling of the export/import scripts is for backwards
-# compatibility with older shared jenkins library
-cleanup=()
-if [ ! -f "$SCRIPT_DIR/export-project.sh" ]; then
-  export_url="https://$BITBUCKET_HOST/projects/$ODS_BITBUCKET_PROJECT/repos/ods-core/raw/ocp-scripts/export-project.sh?at=refs%2Fheads%2F${SCRIPT_BRANCH}"
-  echo "Retrieving missing export-project.sh from $export_url"
-  file="$SCRIPT_DIR/export-project.sh"
-  curl --fail -s --user $CREDENTIALS -G $export_url -d raw -o "$file"
-  cleanup+=( "$file" )
-fi
-if [ ! -f "$SCRIPT_DIR/import-project.sh" ]; then
-  import_url="https://$BITBUCKET_HOST/projects/$ODS_BITBUCKET_PROJECT/repos/ods-core/raw/ocp-scripts/import-project.sh?at=refs%2Fheads%2F${SCRIPT_BRANCH}"
-  echo "Retrieving missing import-project.sh from $import_url"
-  file="$SCRIPT_DIR/import-project.sh"
-  curl --fail -s --user $CREDENTIALS -G $import_url -d raw -o "$file"
-  cleanup+=( "$file" )
-fi
-
-cd migration_config
-echo $(pwd)
+cd oc_migration_scripts/migration_config
+pwd
 
 echo "Creating source file"
 echo "oc_env=$OPENSHIFT_HOST" > ocp_project_config_source
@@ -136,9 +96,10 @@ echo "oc_env=$OPENSHIFT_HOST" > ocp_project_config_target
 echo "OD_OCP_CD_SA_TARGET=$(oc whoami | sed  -e 's/system:serviceaccount://g')" >> ocp_project_config_target
 
 cd ..
-echo $(pwd)
+pwd
 
-git_url="https://${CREDENTIALS//@/%40}@$BITBUCKET_HOST/scm/$PROJECT_ID/$PROJECT_ID-occonfig-artifacts.git"
+# credentials are expected to be managed by netrc or supplied by OS/user interaction.
+git_url="https://$BITBUCKET_HOST/scm/$PROJECT_ID/$PROJECT_ID-occonfig-artifacts.git"
 
 if [[ -z "$DEBUG" ]]; then
   verbose=""
@@ -147,25 +108,22 @@ else
 fi
 
 echo "[INFO]: export resources from $SOURCE_ENV"
-sh "$SCRIPT_DIR/export-project.sh" -p $PROJECT_ID -h $OPENSHIFT_HOST -e $SOURCE_ENV -g $git_url -gb $GIT_BRANCH -cpj $verbose
+sh "$SCRIPT_DIR/export-project.sh" -p "$PROJECT_ID" -h "$OPENSHIFT_HOST" -e "$SOURCE_ENV" -g "$git_url" -gb "$GIT_BRANCH" -cpj "$verbose"
 echo "[INFO]: import resources into $TARGET_ENV"
-sh "$SCRIPT_DIR/import-project.sh" -h $OPENSHIFT_HOST -p $PROJECT_ID -e $SOURCE_ENV -g $git_url -gb $GIT_BRANCH -n $TARGET_PROJECT $verbose --apply true
+sh "$SCRIPT_DIR/import-project.sh" -h "$OPENSHIFT_HOST" -p "$PROJECT_ID" -e "$SOURCE_ENV" -g "$git_url" -gb "$GIT_BRANCH" -n "$TARGET_PROJECT" "$verbose" --apply true
 
 echo "[INFO]: cleanup workplace"
 cd ..
 rm -rf oc_migration_scripts
-for file in "${cleanup[@]}"; do
-  rm "$file"
-done
 
-if [[ ! -z "$SKIP_TAGS" ]]; then
+if [[ -n "$SKIP_TAGS" ]]; then
   echo "[INFO] Skipping imagestream tagging"
   return
 fi
 
 echo "[INFO]: import image tags from $SOURCE_ENV"
-oc get is --no-headers -n $SOURCE_PROJECT | awk '{print $2}' | while read DOCKER_REPO; do
+oc get is --no-headers -n "$SOURCE_PROJECT" | awk '{print $2}' | while read -r DOCKER_REPO; do
   echo "[INFO]: importing latest image from ${DOCKER_REPO}"
   image="${DOCKER_REPO}:latest"
-  oc tag ${SOURCE_PROJECT}/${image} ${image} -n $TARGET_PROJECT || true
+  oc tag "${SOURCE_PROJECT}/${image}" "${image}" -n "$TARGET_PROJECT" || true
 done

--- a/ocp-scripts/clone-project.sh
+++ b/ocp-scripts/clone-project.sh
@@ -113,6 +113,7 @@ echo "[INFO]: import resources into $TARGET_ENV"
 sh "$SCRIPT_DIR/import-project.sh" -h "$OPENSHIFT_HOST" -p "$PROJECT_ID" -e "$SOURCE_ENV" -g "$git_url" -gb "$GIT_BRANCH" -n "$TARGET_PROJECT" "$verbose" --apply true
 
 echo "[INFO]: cleanup workplace"
+# shellcheck disable=SC2124
 cd ..
 rm -rf oc_migration_scripts
 

--- a/ocp-scripts/clone-project.sh
+++ b/ocp-scripts/clone-project.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2103
+
 set -e
 # removing option -x to avoid disclosure of passwords/tokens
 
@@ -113,7 +115,6 @@ echo "[INFO]: import resources into $TARGET_ENV"
 sh "$SCRIPT_DIR/import-project.sh" -h "$OPENSHIFT_HOST" -p "$PROJECT_ID" -e "$SOURCE_ENV" -g "$git_url" -gb "$GIT_BRANCH" -n "$TARGET_PROJECT" "$verbose" --apply true
 
 echo "[INFO]: cleanup workplace"
-# shellcheck disable=SC2103
 cd ..
 rm -rf oc_migration_scripts
 

--- a/ocp-scripts/verify-jsl-expectations.sh
+++ b/ocp-scripts/verify-jsl-expectations.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script verifies that the clone-project.sh and the export-/import
+# scripts used by it are not inadvertantly renamed.
+# ods-jenkins-shared-library depends on this.
+
+# The script is expected to be exucuted from the project root.
+
+set -e
+
+script_names=(clone-project.sh export-project.sh export-project.sh)
+
+for name in "${script_names[@]}"; do
+    script_name="ocp-scripts/$name"
+    if [ ! -f "$script_name" ]; then
+        echo "$script_name must exist: ods-jenkins-shared-library depends on this"
+        exit 1
+    fi
+done


### PR DESCRIPTION
This is to be delivered with https://github.com/opendevstack/ods-jenkins-shared-library/pull/363.

Credential handling is now expected to be supplied external to the script, namely interactively/OS integration.

This can be done by having a netrc file in place or using a git credential handler.

This also removes code for backwards compatibility with pre 2.x ods-jenkins-shared-library versions.

Also adds some checking of assumptions made in ods-jenkins-shared-library about the names of the scripts so that inadvertent changes in naming should be caught. Also extends some shellcheck testing. 

See https://github.com/opendevstack/ods-jenkins-shared-library/issues/112#issuecomment-629282926 for additional context.