### PR TITLE
Delete .kube directory before booting Jenkins

### DIFF
--- a/jenkins/master/ods-run
+++ b/jenkins/master/ods-run
@@ -4,6 +4,9 @@
 # then delegates to the original run script of the base image.
 set -ue
 
+echo "Deleting .kube to avoid weird caching issues (see https://github.com/opendevstack/ods-core/issues/473)"
+rm -rf $HOME/.kube || true
+
 # Openshift default CA. See https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
 SERVICEACCOUNT_CA='/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt'
 if [[ -f $SERVICEACCOUNT_CA ]]; then


### PR DESCRIPTION
It seems that some things get cached there and might get corrupted which
prevents new builds from running.

Deleting the directory seems to be fine, as it is created automatically
by the OpenShift Sync plugin anyway.

Closes #473.

@clemensutschig You were right, seems to work just fine!