### PR TITLE
Split prov app / doc gen targets for more fine-grained control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,16 +89,20 @@ apply-provisioning-app-deploy:
 .PHONY: apply-provisioning-app-deploy
 
 
-# DOCUMENT GENERATION SERVICE
-## Install the documentation generation service.
-install-doc-gen: apply-doc-gen-build
+# DOCUMENT GENERATION SERVICE IMAGE
+## Install the documentation generation image.
+install-doc-gen: apply-doc-gen-build import-doc-gen-image
 .PHONY: install-doc-gen
 
 ## Update OpenShift resources related to the Document Generation image.
 apply-doc-gen-build:
 	cd ods-document-generation-svc/ocp-config && tailor apply --namespace ${NAMESPACE}
-	ocp-scripts/import-image-from-dockerhub.sh --namespace ${NAMESPACE} --image ods-document-generation-svc --target-stream ods-doc-gen-svc
 .PHONY: apply-doc-gen-build
+
+## Import Document Generation image from DockerHub.
+import-doc-gen-image:
+	ocp-scripts/import-image-from-dockerhub.sh --namespace ${NAMESPACE} --image ods-document-generation-svc --target-stream ods-doc-gen-svc
+.PHONY:import-doc-gen-image
 
 
 # SONARQUBE

--- a/Makefile
+++ b/Makefile
@@ -69,14 +69,22 @@ start-jenkins-build-webhook-proxy:
 
 
 # PROVISIONING APP
-## Install the provision app.
-install-provisioning-app: apply-provisioning-app-deploy
+## Install the provisioning app.
+install-provisioning-app: apply-provisioning-app-build import-provisioning-app-image apply-provisioning-app-deploy
 .PHONY: install-provisioning-app
+
+## Update OpenShift resources related to the Provisioning App image.
+apply-provisioning-app-build:
+	cd ods-provisioning-app/ocp-config && tailor apply --namespace ${NAMESPACE} is
+.PHONY: apply-provisioning-app-build
+
+## Import Provisioning App image from DockerHub.
+import-provisioning-app-image:
+	ocp-scripts/import-image-from-dockerhub.sh --namespace ${NAMESPACE} --image ods-provisioning-app --target-stream ods-provisioning-app
+.PHONY: import-provisioning-app-image
 
 ## Update OpenShift resources related to the Provisioning App service.
 apply-provisioning-app-deploy:
-	cd ods-provisioning-app/ocp-config && tailor apply --namespace ${NAMESPACE} is
-	ocp-scripts/import-image-from-dockerhub.sh --namespace ${NAMESPACE} --image ods-provisioning-app --target-stream ods-provisioning-app
 	cd ods-provisioning-app/ocp-config && tailor apply --namespace ${NAMESPACE} --exclude is
 .PHONY: apply-provisioning-app-deploy
 


### PR DESCRIPTION
Example use case: update just the deploy resources (e.g. the `ConfigMap`) without touching the image.