### PR TITLE
Use BITBUCKET_URL in Jenkins master

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -108,10 +108,10 @@ CROWD_URL=http://192.168.56.31:8095/crowd
 # Bitbucket host (without protocol!)
 BITBUCKET_HOST=192.168.56.31:7990
 
-# bitbucket url - inncluding protocol
+# Bitbucket URL (including protocol!)
 BITBUCKET_URL=http://192.168.56.31:7990
 
-# Git repository base URL
+# Git repository base URL (including protocol!)
 REPO_BASE=http://192.168.56.31:7990/scm
 
 CD_USER_ID=cd_user

--- a/create-projects/Jenkinsfile
+++ b/create-projects/Jenkinsfile
@@ -11,18 +11,26 @@ def cdUserIdB64 = env.CD_USER_ID_B64
 def cdUserType = env.CD_USER_TYPE
 
 // Jenkins DeploymentConfig environment variables
-def bitbucketHost
+def bitbucketUrl
 def dockerRegistry
-
 def pipelineOpenShiftProject
 node {
   dockerRegistry = env.DOCKER_REGISTRY
-  bitbucketHost = env.GIT_SERVER_URL ?: env.BITBUCKET_HOST
-  echo("Resolved variable 'bitbucketHost' to '${bitbucketHost}'! [defaultHost=${env.BITBUCKET_HOST}, customHost=${env.GIT_SERVER_URL}]")
+  if (env.GIT_SERVER_URL) {
+    bitbucketUrl = env.GIT_SERVER_URL
+  } else if (env.BITBUCKET_URL) {
+    bitbucketUrl = env.BITBUCKET_URL
+  } else if (env.BITBUCKET_HOST) {
+    bitbucketUrl = env.BITBUCKET_HOST // Fallback for Jenkins master instances not updated from 2.x
+  } else {
+    error('''Neither 'GIT_SERVER_URL' nor 'BITBUCKET_URL' is present, but at least one is required.''')
+  }
+  if (!bitbucketUrl.contains('://')) {
+    bitbucketUrl = "https://${bitbucketUrl}" // Fallback for old provisioning app instances not updated from 2.x
+  }
+  echo("Resolved variable 'bitbucketUrl' to '${bitbucketUrl}'! [default=${env.BITBUCKET_URL}, custom=${env.GIT_SERVER_URL}]")
   pipelineOpenShiftProject = env.JOB_NAME.split('/').first()
 }
-
-def gitIsHttps = false
 
 def conts = containerTemplate(
   name: 'jnlp',
@@ -46,16 +54,10 @@ podTemplate(
       sh 'mkdir -p ods-core'
       dir('ods-core') {
         checkout scm
-        gitIsHttps = sh(
-          returnStdout: true,
-          script: 'git config remote.origin.url'
-        ).trim().startsWith("https")
       }
     }
 
     stage('Checkout ods-configuration') {
-      def bitbucketScheme = gitIsHttps ? 'https://' : 'http://'
-      def bitbucketUrl = bitbucketScheme + bitbucketHost;
       echo("Getting ods configuration from ${bitbucketHost}")
       checkout([
         $class: 'GitSCM',

--- a/jenkins/ocp-config/deploy/jenkins-master.yml
+++ b/jenkins/ocp-config/deploy/jenkins-master.yml
@@ -54,7 +54,7 @@ parameters:
   required: true
 - name: DOCKER_REGISTRY
   required: true
-- name: BITBUCKET_HOST
+- name: BITBUCKET_URL
   required: true
 - name: REPO_BASE
   required: true
@@ -191,8 +191,8 @@ objects:
               value: '${SHARED_LIBRARY_REPOSITORY}'
             - name: DOCKER_REGISTRY
               value: '${DOCKER_REGISTRY}'
-            - name: BITBUCKET_HOST
-              value: '${BITBUCKET_HOST}'
+            - name: BITBUCKET_URL
+              value: '${BITBUCKET_URL}'
           image: '${DOCKER_REGISTRY}/${ODS_NAMESPACE}/jenkins-master:${ODS_IMAGE_TAG}'
           imagePullPolicy: IfNotPresent
           livenessProbe:


### PR DESCRIPTION
This works because the shared library can read both `BITBUCKET_URL` and
`BITBUCKET_HOST`.

The prov app will - going forward - send GIT_SERVER_URL as a full URL with scheme, so
we remove the detection if Git is HTTPS or not. Only a safeguard
defaulting to HTTPS stays to ease the transition time.