### PR TITLE
Add script to manage Bitbucket ODS project and repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,15 @@ NEXUS_URL=
 SONARQUBE_URL=
 
 # REPOSITORIES
+## Prepare Bitbucket repos (create project and repos).
+prepare-bitbucket-repos:
+	cd ods-setup && ./bitbucket.sh
+.PHONY: prepare-bitbucket-repos
+
 ## Prepare local repos (fetch changes from Bitbucket).
-prepare-repos:
+prepare-local-repos:
 	cd ods-setup && ./repos.sh --confirm
-.PHONY: prepare-repos
+.PHONY: prepare-local-repos
 
 ## Sync repos (fetch changes from GitHub, and synchronize with Bitbucket).
 sync-repos:

--- a/docs/modules/administration/nav.adoc
+++ b/docs/modules/administration/nav.adoc
@@ -1,8 +1,5 @@
 * Administration
 ** xref:administration:installation.adoc[Installation]
-*** xref:administration:local-install-requirements.adoc[Local Installation Requirements]
-*** xref:administration:install-guide.adoc[Local Installation (outdated)]
-*** xref:administration:infrastructure-setup.adoc[Infrastructure Setup (outdated)]
 ** xref:administration:update.adoc[Upgrade]
 ** xref:provisioning-app:configuration.adoc[Provisioning App]
 ** xref:administration:keycloak.adoc[Keycloak]

--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -8,7 +8,7 @@ NOTE: From now on we assume, you work from a Bash (Cygwin / Linux).
 
 In order to run the Atlassian suite and OpenShift, your host must have:
 
-- At least 16GB RAM
+- At least 16GB RAM and 32GB of available disk space
 - `vm.max_map_count=262144` to run SonarQube (which can be set via `sudo sysctl -w vm.max_map_count=262144`)
 - A recent Git version (>= 2.7.0)
 

--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -99,18 +99,23 @@ TIP: If you are on Linux, `oc cluster up` will do the trick.
 
 == Bitbucket Repoisitories
 
-Ensure that there is an `OPENDEVSTACK` project in Bitbucket and that there is a corresponding OpenDevStack repository for each ODS repository that you have locally. In the next step, they will be filled / updated with the latest state so that they can be used e.g. from `BuildConfig` resources in OpenShift.
+On Bitbucket, there must be an `OPENDEVSTACK` project filled with the necessary repositories such as `ods-core`. To set them up, use:
 
-In `ods-core` run:
+[source,sh]
+----
+make prepare-bitbucket-repos
+----
+
+Then, update them with the latest state so that they can be used e.g. from `BuildConfig` resources in OpenShift:
 [source,sh]
 ----
 make sync-repos
 ----
 
-Next, in `ods-configuration` run:
+You also need to update `ods-configuration`, which can be done via:
 [source,sh]
 ----
-git push origin master
+git push -u origin master
 ----
 
 == OpenDevStack environment in OpenShift

--- a/ods-setup/bitbucket.sh
+++ b/ods-setup/bitbucket.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -ue
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_CORE_DIR=${SCRIPT_DIR%/*}
+ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
+
+echo_done(){
+    echo -e "\033[92mDONE\033[39m: $1"
+}
+
+echo_warn(){
+    echo -e "\033[93mWARN\033[39m: $1"
+}
+
+echo_error(){
+    echo -e "\033[31mERROR\033[39m: $1"
+}
+
+echo_info(){
+    echo -e "\033[94mINFO\033[39m: $1"
+}
+
+BITBUCKET_URL=""
+BITBUCKET_USER=""
+BITBUCKET_PWD=""
+BITBUCKET_ODS_PROJECT="OPENDEVSTACK"
+INSECURE=""
+
+function usage {
+    printf "Initialise OpenDevStack Bitbucket project.\n\n"
+    printf "This script will ask interactively for parameters by default.\n"
+    printf "However, you can also pass them directly. Usage:\n\n"
+    printf "\t-h|--help\t\tPrint usage\n"
+    printf "\t-v|--verbose\t\tEnable verbose mode\n"
+    printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
+    printf "\n"
+    printf "\t-b|--bitbucket\t\tBitbucket URL, e.g. 'https://bitbucket.example.com'\n"
+    printf "\t-u|--user\t\tBitbucket user\n"
+    printf "\t-p|--password\t\tBitbucket password\n"
+    printf "\t-o|--ods-project\tName of OpenDevStack project (defaults to '%s')\n" "${BITBUCKET_ODS_PROJECT}"
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+
+    -v|--verbose) set -x;;
+
+    -h|--help) usage; exit 0;;
+
+    -i|--insecure) INSECURE="yes";;
+
+    -b|--bitbucket) BITBUCKET_URL="$2"; shift;;
+    -b=*|--bitbucket=*) BITBUCKET_URL="${1#*=}";;
+
+    -u|--user) BITBUCKET_USER="$2"; shift;;
+    -u=*|--user=*) BITBUCKET_USER="${1#*=}";;
+
+    -p|--password) BITBUCKET_PWD="$2"; shift;;
+    -p=*|--password=*) BITBUCKET_PWD="${1#*=}";;
+
+    -o|--ods-project) BITBUCKET_ODS_PROJECT="$2"; shift;;
+    -o=*|--ods-project=*) BITBUCKET_ODS_PROJECT="${1#*=}";;
+
+  *) echo_error "Unknown parameter passed: $1"; exit 1;;
+esac; shift; done
+
+if [ -z "${BITBUCKET_URL}" ]; then
+    configuredUrl="https://bitbucket.example.com"
+    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
+        echo_info "Configuration located"
+        configuredUrl=$(grep BITBUCKET_URL "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
+    fi
+    read -r -e -p "Enter Bitbucket URL [${configuredUrl}]: " input
+    if [ -z "${input}" ]; then
+        BITBUCKET_URL=${configuredUrl}
+    else
+        BITBUCKET_URL="${input}"
+    fi
+fi
+
+if [ -z "${BITBUCKET_USER}" ]; then
+    read -r -e -p "Enter Bitbucket user on ${BITBUCKET_URL}: " input
+    BITBUCKET_USER="${input}"
+fi
+
+if [ -z "${BITBUCKET_PWD}" ]; then
+    read -r -e -p "Enter Bitbucket password for user '${BITBUCKET_USER}': " input
+    BITBUCKET_PWD="${input}"
+fi
+
+# Create project OPENDEVSTACK if it does not exist yet
+httpCode=$(curl ${INSECURE:"--insecure"} -sS -o /dev/null -w "%{http_code}" \
+    --user "${BITBUCKET_USER}:${BITBUCKET_PWD}" \
+    "${BITBUCKET_URL}/rest/api/1.0/projects/${BITBUCKET_ODS_PROJECT}")
+if [ "${httpCode}" == "404" ]; then
+    echo_info "Creating project ${BITBUCKET_ODS_PROJECT} in Bitbucket"
+    curl ${INSECURE:"--insecure"} -sSf -X POST \
+        --user "${BITBUCKET_USER}:${BITBUCKET_PWD}" \
+        -H "Content-Type: application/json" \
+        -d "{\"key\":\"${BITBUCKET_ODS_PROJECT}\", \"name\": \"${BITBUCKET_ODS_PROJECT}\", \"description\": \"OpenDevStack\"}" \
+        "${BITBUCKET_URL}/rest/api/1.0/projects"
+elif [ "${httpCode}" == "200" ]; then
+    echo_info "Found project ${BITBUCKET_ODS_PROJECT} in Bitbucket."
+else
+    echo_error "Could not determine state of project ${BITBUCKET_ODS_PROJECT} on Bitbucket, got ${httpCode}."
+    exit 1
+fi
+
+# For each of the listed names, a repository will be created in the local bitbucket
+# instance under the OPENDEVSTACK project. The list should be synced with the repo
+# list in ods-core/ods-setup/repos.sh.
+for repository in ods-core ods-quickstarters ods-jenkins-shared-library ods-configuration; do
+    httpCode=$(curl ${INSECURE:"--insecure"} -sS -o /dev/null -w "%{http_code}" \
+        --user "${BITBUCKET_USER}:${BITBUCKET_PWD}" \
+        "${BITBUCKET_URL}/rest/api/1.0/projects/${BITBUCKET_ODS_PROJECT}/repos/${repository}")
+    if [ "${httpCode}" == "404" ]; then
+        echo_info "Creating repository ${BITBUCKET_ODS_PROJECT}/${repository} on Bitbucket."
+        curl ${INSECURE:"--insecure"} -sSf -X POST \
+            --user "${BITBUCKET_USER}:${BITBUCKET_PWD}" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\":\"${repository}\", \"scmId\": \"git\", \"forkable\": true}" \
+            "${BITBUCKET_URL}/rest/api/1.0/projects/${BITBUCKET_ODS_PROJECT}/repos"
+    elif [ "${httpCode}" == "200" ]; then
+        echo_info "Repository ${BITBUCKET_ODS_PROJECT}/${repository} exists already on Bitbucket."
+    else 
+        echo_error "Could not determine state of ${BITBUCKET_ODS_PROJECT}/${repository} on Bitbucket, got ${httpCode}."
+        exit 1
+    fi
+done
+
+echo_done "Bitbucket project ${BITBUCKET_ODS_PROJECT} configured"


### PR DESCRIPTION
Inspired by the solution in #549.

@georgfedermann Please use this script instead. It adds a few improvements, e.g. it can be used now if the project/repos exist already or not. Therefore it is now suitable when installing manually.