### PR TITLE
Improve shell scripts

### DIFF
--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -10,7 +10,8 @@ In order to run the Atlassian suite and OpenShift, your host must have:
 
 - At least 16GB RAM
 - `vm.max_map_count=262144` to run SonarQube (which can be set via `sudo sysctl -w vm.max_map_count=262144`)
-- A recent Git version (>= 2.7.0)
+- A recent `git` version (>= 2.7.0)
+- A recent `jq` version (>= 1.5, see https://stedolan.github.io/jq/)
 
 == Local Setup
 

--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -28,7 +28,7 @@ NEXUS_URL=
 LOCAL_CONTAINER_ID=
 NAMESPACE="ods"
 NEXUS_DC="nexus"
-INSECURE=
+INSECURE=""
 
 function usage {
     printf "Setup Nexus.\n\n"
@@ -36,11 +36,13 @@ function usage {
     printf "However, you can also pass them directly. Usage:\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
-    printf "\t-n|--nexus\t\tNexus URL, e.g. 'https://nexus.example.com'\n"
+    printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
+    printf "\n"
+    printf "\t-n|--nexus\t\t\tNexus URL, e.g. 'https://nexus.example.com'\n"
     printf "\t-l|--local-container-id\t\tLocal container ID\n"
     printf "\t-a|--admin-password\t\tAdmin password\n"
     printf "\t-d|--developer-password\t\tDeveloper password\n"
-    printf "\t-n|--namespace\tNamespace (defaults to '%s')\n" "${NAMESPACE}"
+    printf "\t-n|--namespace\t\t\tNamespace (defaults to '%s')\n" "${NAMESPACE}"
 }
 
 while [[ "$#" -gt 0 ]]; do

--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -122,7 +122,7 @@ function waitForReady {
     local n=0
     local httpOk=
     until [ $n -ge 20 ]; do
-        httpOk=$(curl ${INSECURE} --silent -o /dev/null -w "%{http_code}" "${NEXUS_URL}/service/rest/v1/status/writable")
+        httpOk=$(curl ${INSECURE} -sS -o /dev/null -w "%{http_code}" "${NEXUS_URL}/service/rest/v1/status/writable")
         if [ "${httpOk}" == "200" ]; then
             echo_info "Nexus is up"
             break
@@ -145,15 +145,15 @@ function runJsonScript {
     shift 1
     # shellcheck disable=SC2124
     local runParams="$@"
-    curl ${INSECURE} -X POST --fail --silent \
+    curl ${INSECURE} -X POST -sSf \
         --user "${ADMIN_USER}:${ADMIN_PASSWORD}" \
         --header 'Content-Type: application/json' \
         "${NEXUS_URL}/service/rest/v1/script" -d @json/"${jsonScriptName}".json
-    curl ${INSECURE} -X POST --fail --silent \
+    curl ${INSECURE} -X POST -sSf \
         --user "${ADMIN_USER}:${ADMIN_PASSWORD}" \
         --header 'Content-Type: text/plain' \
         "${NEXUS_URL}/service/rest/v1/script/${jsonScriptName}/run" ${runParams} > /dev/null
-    curl ${INSECURE} -X DELETE --fail --silent \
+    curl ${INSECURE} -X DELETE -sSf \
         --user "${ADMIN_USER}:${ADMIN_PASSWORD}" \
         "${NEXUS_URL}/service/rest/v1/script/${jsonScriptName}"
 }
@@ -193,19 +193,19 @@ else
     ADMIN_DEFAULT_PASSWORD=$(docker exec -t "${LOCAL_CONTAINER_ID}" sh -c "cat ${DEFAULT_ADMIN_PASSWORD_FILE} 2> /dev/null || true")
 fi
 if [ -n "${ADMIN_DEFAULT_PASSWORD}" ]; then
-    pong=$(curl ${INSECURE} --silent --user "${ADMIN_USER}:${ADMIN_DEFAULT_PASSWORD}" \
+    pong=$(curl ${INSECURE} -sS --user "${ADMIN_USER}:${ADMIN_DEFAULT_PASSWORD}" \
         "${NEXUS_URL}/service/metrics/ping")
     if [ "${pong}" == "pong" ]; then
         echo_info "Change admin password"
-        curl ${INSECURE} -X POST --fail --silent \
+        curl ${INSECURE} -X POST -sSf \
             --user "${ADMIN_USER}:${ADMIN_DEFAULT_PASSWORD}" \
             --header 'Content-Type: application/json' \
             "${NEXUS_URL}/service/rest/v1/script" -d @json/changeAdminPassword.json
-        curl ${INSECURE} -X POST --fail --silent \
+        curl ${INSECURE} -X POST -sSf \
             --user "${ADMIN_USER}:${ADMIN_DEFAULT_PASSWORD}" \
             --header 'Content-Type: text/plain' \
             "${NEXUS_URL}/service/rest/v1/script/changeAdminPassword/run" -d "${ADMIN_PASSWORD}" > /dev/null
-        curl ${INSECURE} -X DELETE --fail --silent \
+        curl ${INSECURE} -X DELETE -sSf \
             --user "${ADMIN_USER}:${ADMIN_PASSWORD}" \
             "${NEXUS_URL}/service/rest/v1/script/changeAdminPassword"
     fi

--- a/nexus/test.sh
+++ b/nexus/test.sh
@@ -56,9 +56,7 @@ expectedBlobstores=( "candidates"
                      "pypi-private"
                      "leva-documentation" )
 
-actualBlobstores=$(curl \
-    --fail \
-    --silent \
+actualBlobstores=$(curl -sSf \
     --user "${ADMIN_USER_NAME}:${ADMIN_USER_PWD}" \
     ${NEXUS_URL}/service/rest/beta/blobstores)
 
@@ -89,9 +87,7 @@ expectedRepos=( "candidates:hosted"
                 "pypi-all:group"
                 "leva-documentation:hosted")
 
-actualRepos=$(curl \
-    --fail \
-    --silent \
+actualRepos=$(curl -sSf \
     --user "${ADMIN_USER_NAME}:${ADMIN_USER_PWD}" \
     ${NEXUS_URL}/service/rest/v1/repositories)
 
@@ -113,7 +109,7 @@ for repo in "${expectedRepos[@]}"; do
 done
 
 echo "Check if anonymous access is still possible"
-if curl --fail --silent \
+if curl -sSf \
     ${NEXUS_URL}/service/rest/v1/repositories | jq -e "length > 0" > /dev/null; then
     echo "Anonymous access still possible"
     exit 1
@@ -122,7 +118,7 @@ else
 fi
 
 echo "Check developer access"
-if curl --fail --silent \
+if curl -sSf \
     --user "${DEV_USER_NAME}:${DEV_USER_PWD}" \
     ${NEXUS_URL}/service/rest/v1/repositories | jq -e "length == 0" > /dev/null; then
     echo "Developer access not possible"

--- a/sonarqube/configure.sh
+++ b/sonarqube/configure.sh
@@ -28,7 +28,7 @@ PIPELINE_USER_NAME="cd_user"
 PIPELINE_USER_PWD=""
 TOKEN_NAME="ods-jenkins-shared-library"
 SONARQUBE_URL=
-INSECURE=
+INSECURE=""
 
 function usage {
     printf "Setup SonarQube.\n\n"
@@ -36,8 +36,10 @@ function usage {
     printf "However, you can also pass them directly. Usage:\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
+    printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
+    printf "\n"
     printf "\t-s|--sonarqube\t\tSonarQube URL, e.g. 'https://sonarqube.example.com'\n"
-    printf "\t-a|--admin-password\t\tAdmin password\n"
+    printf "\t-a|--admin-password\tAdmin password\n"
     printf "\t-p|--pipeline-user\tName of Jenkins pipeline user (defaults to 'cd_user')\n"
     printf "\t-t|--token-name\t\tName of SonarQube user token (defaults to 'ods-jenkins-shared-library')\n"
 }

--- a/sonarqube/configure.sh
+++ b/sonarqube/configure.sh
@@ -67,11 +67,8 @@ while [[ "$#" -gt 0 ]]; do
 esac; shift; done
 
 if ! which jq >/dev/null; then
-    echo_warn "Binary 'jq' (https://stedolan.github.io/jq/) is not in your PATH. This will make the script less comfortable to use."
-    read -r -e -p "Continue anyway? [y/n] " input
-    if [ "${input:-""}" != "y" ]; then
-        exit 1
-    fi
+    echo_error "'jq' (https://stedolan.github.io/jq/) is not in your \$PATH."
+    exit 1
 fi
 
 if [ -z "${SONARQUBE_URL}" ]; then
@@ -182,14 +179,10 @@ else
         "${SONARQUBE_URL}/api/user_tokens/generate?login=${PIPELINE_USER_NAME}&name=${TOKEN_NAME}")
     # Example response:
     # {"login":"cd_user","name":"foo","token":"bar","createdAt":"2020-04-22T13:21:54+0000"}
-    if which jq >/dev/null; then
-        token=$(echo "${tokenResponse}" | jq -r .token)
-        echo_info "Created token: ${token}"
-        base64Token=$(echo -n "${token}" | base64)
-        echo_info "Base64-encoded token to use for 'SONAR_AUTH_TOKEN_B64': ${base64Token}"
-    else
-        echo_info "Created token! Response: ${tokenResponse}"
-    fi
+    token=$(echo "${tokenResponse}" | jq -r .token)
+    echo_info "Created token: ${token}"
+    base64Token=$(echo -n "${token}" | base64)
+    echo_info "Base64-encoded token to use for 'SONAR_AUTH_TOKEN_B64': ${base64Token}"
 fi
 
 echo "If configuration needs to be updated, please add the base64 encoded token and the admin password into ods-core.env."

--- a/sonarqube/configure.sh
+++ b/sonarqube/configure.sh
@@ -23,9 +23,9 @@ echo_info(){
 
 ADMIN_USER_NAME="admin"
 ADMIN_USER_DEFAULT_PASSWORD="admin"
-ADMIN_USER_PASSWORD=
+ADMIN_USER_PASSWORD=""
 PIPELINE_USER_NAME="cd_user"
-PIPELINE_USER_PWD=
+PIPELINE_USER_PWD=""
 TOKEN_NAME="ods-jenkins-shared-library"
 SONARQUBE_URL=
 INSECURE=
@@ -56,6 +56,9 @@ while [[ "$#" -gt 0 ]]; do
 
     -p|--pipeline-user) PIPELINE_USER_NAME="$2"; shift;;
     -p=*|--pipeline-user=*) PIPELINE_USER_NAME="${1#*=}";;
+
+    -w|--pipeline-user-password) PIPELINE_USER_PWD="$2"; shift;;
+    -w=*|--pipeline-user-password=*) PIPELINE_USER_PWD="${1#*=}";;
 
     -t|--token-name) TOKEN_NAME="$2"; shift;;
     -t=*|--token-name=*) TOKEN_NAME="${1#*=}";;

--- a/sonarqube/configure.sh
+++ b/sonarqube/configure.sh
@@ -3,6 +3,7 @@ set -ue
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}
+ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
 echo_done(){
     echo -e "\033[92mDONE\033[39m: $1"
@@ -74,10 +75,10 @@ if ! which jq >/dev/null; then
 fi
 
 if [ -z "${SONARQUBE_URL}" ]; then
-    configuredUrl="https://example.sonarqube.com"
-    if [ -f "${ODS_CORE_DIR}/../ods-configuration/ods-core.env" ]; then
+    configuredUrl="https://sonarqube.example.com"
+    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
         echo_info "Configuration located"
-        configuredUrl=$(grep SONARQUBE_URL "${ODS_CORE_DIR}/../ods-configuration/ods-core.env" | cut -d "=" -f 2-)
+        configuredUrl=$(grep SONARQUBE_URL "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
     fi
     read -r -e -p "Enter SonarQube URL [${configuredUrl}]: " input
     if [ -z "${input}" ]; then
@@ -88,10 +89,10 @@ if [ -z "${SONARQUBE_URL}" ]; then
 fi
 
 if [ -z "${ADMIN_USER_PASSWORD}" ]; then
-    if [ -f "${ODS_CORE_DIR}/../ods-configuration/ods-core.env" ]; then
+    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
         echo_info "Configuration located, checking if password is changed from sample value"
         samplePassword=$(grep SONAR_ADMIN_PASSWORD_B64 "${ODS_CORE_DIR}/configuration-sample/ods-core.env.sample" | cut -d "=" -f 2-)
-        configuredPassword=$(grep SONAR_ADMIN_PASSWORD_B64 "${ODS_CORE_DIR}/../ods-configuration/ods-core.env" | cut -d "=" -f 2- | base64 --decode)
+        configuredPassword=$(grep SONAR_ADMIN_PASSWORD_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2- | base64 --decode)
         if [ "${configuredPassword}" == "${samplePassword}" ]; then
             echo_info "Admin password in ods-configuration/ods-core.env is the sample value"
         else


### PR DESCRIPTION
A couple of improvements:

* Add missing parameters (taken from #549)
* Show `curl` errors in silent mode
* Make `jq` required (will allow us to write the SQ config into the file in the future, making it even more automated)
* Some help display changes