### PR TITLE
Specify Jenkins CPU resources

### DIFF
--- a/jenkins/ocp-config/deploy/jenkins-master.yml
+++ b/jenkins/ocp-config/deploy/jenkins-master.yml
@@ -20,6 +20,10 @@ parameters:
   value: 5Gi
 - name: JENKINS_MEMORY_REQUEST
   value: 2560Mi
+- name: JENKINS_CPU_LIMIT
+  value: "1"
+- name: JENKINS_CPU_REQUEST
+  value: 100m
 - name: JENKINS_VOLUME_CAPACITY
   value: 5Gi
 - name: JENKINS_JAVA_GC_OPTS
@@ -218,9 +222,11 @@ objects:
             timeoutSeconds: 3
           resources:
             limits:
-              memory: '${JENKINS_MEMORY_LIMIT}'
+              cpu: ${JENKINS_CPU_LIMIT}
+              memory: ${JENKINS_MEMORY_LIMIT}
             requests:
-              memory: '${JENKINS_MEMORY_REQUEST}'
+              cpu: ${JENKINS_CPU_REQUEST}
+              memory: ${JENKINS_MEMORY_REQUEST}
           securityContext:
             capabilities: {}
             privileged: false

--- a/jenkins/ocp-config/deploy/jenkins-master.yml
+++ b/jenkins/ocp-config/deploy/jenkins-master.yml
@@ -198,7 +198,7 @@ objects:
             - name: BITBUCKET_URL
               value: '${BITBUCKET_URL}'
           image: '${DOCKER_REGISTRY}/${ODS_NAMESPACE}/jenkins-master:${ODS_IMAGE_TAG}'
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 30
             httpGet:


### PR DESCRIPTION
Closes #612.

Also, I noticed that the image would only be pulled if it isn't present. That's no good because then any updates to the image (and we typically update e.g. the `3.x` image tag) will have no effect when restarting.