### PR TITLE
Write updated SQ config values to ods-core.env

### DIFF
--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -162,7 +162,7 @@ make install-sonarqube
 
 This will launch an instance of SonarQube.
 The script will prompt for a new admin password, set it and create an auth token to be used by the Jenkins pipelines.
-At the end, the script will ask you to adjust `ods-configuration/ods-core.env`, which you need to commit and push before continuing.
+Both values can be written into `ods-configuration/ods-core.env`, which you then need to commit and push before continuing.
 
 === Jenkins
 

--- a/sonarqube/configure.sh
+++ b/sonarqube/configure.sh
@@ -27,8 +27,11 @@ ADMIN_USER_PASSWORD=""
 PIPELINE_USER_NAME="cd_user"
 PIPELINE_USER_PWD=""
 TOKEN_NAME="ods-jenkins-shared-library"
-SONARQUBE_URL=
+WRITE_TO_CONFIG=""
+SONARQUBE_URL=""
 INSECURE=""
+CONFIGURATION_LOCATED=""
+VALUES_WRITTEN_TO_CONFIG=""
 
 function usage {
     printf "Setup SonarQube.\n\n"
@@ -42,6 +45,7 @@ function usage {
     printf "\t-a|--admin-password\tAdmin password\n"
     printf "\t-p|--pipeline-user\tName of Jenkins pipeline user (defaults to 'cd_user')\n"
     printf "\t-t|--token-name\t\tName of SonarQube user token (defaults to 'ods-jenkins-shared-library')\n"
+    printf "\t-w|--write-to-config\tIf token/password should be written to ods-core.env\n"
 }
 
 while [[ "$#" -gt 0 ]]; do
@@ -65,6 +69,8 @@ while [[ "$#" -gt 0 ]]; do
     -t|--token-name) TOKEN_NAME="$2"; shift;;
     -t=*|--token-name=*) TOKEN_NAME="${1#*=}";;
 
+    -c|--write-to-config) WRITE_TO_CONFIG="y";;
+
     -s|--sonarqube) SONARQUBE_URL="$2"; shift;;
     -s=*|--sonarqube=*) SONARQUBE_URL="${1#*=}";;
 
@@ -76,10 +82,17 @@ if ! which jq >/dev/null; then
     exit 1
 fi
 
+if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
+    echo_info "Configuration located at ${ODS_CONFIGURATION_DIR}/ods-core.env."
+    CONFIGURATION_LOCATED="y"
+else
+    echo_warn "Configuration could not be located."
+    WRITE_TO_CONFIG="n"
+fi
+
 if [ -z "${SONARQUBE_URL}" ]; then
     configuredUrl="https://sonarqube.example.com"
-    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
-        echo_info "Configuration located"
+    if [ -n "${CONFIGURATION_LOCATED}" ]; then
         configuredUrl=$(grep SONARQUBE_URL "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
     fi
     read -r -e -p "Enter SonarQube URL [${configuredUrl}]: " input
@@ -91,14 +104,14 @@ if [ -z "${SONARQUBE_URL}" ]; then
 fi
 
 if [ -z "${ADMIN_USER_PASSWORD}" ]; then
-    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
-        echo_info "Configuration located, checking if password is changed from sample value"
+    if [ -n "${CONFIGURATION_LOCATED}" ]; then
+        echo_info "Checking if password in ods-configuration/ods-core.env differs from sample value ..."
         samplePassword=$(grep SONAR_ADMIN_PASSWORD_B64 "${ODS_CORE_DIR}/configuration-sample/ods-core.env.sample" | cut -d "=" -f 2-)
         configuredPassword=$(grep SONAR_ADMIN_PASSWORD_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2- | base64 --decode)
         if [ "${configuredPassword}" == "${samplePassword}" ]; then
-            echo_info "Admin password in ods-configuration/ods-core.env is the sample value"
+            echo_info "Admin password in ods-configuration/ods-core.env is the sample value."
         else
-            echo_info "Setting admin password from ods-configuration/ods-core.env"
+            echo_info "Using admin password from ods-configuration/ods-core.env."
             ADMIN_USER_PASSWORD=${configuredPassword}
         fi
     fi
@@ -109,14 +122,14 @@ if [ -z "${ADMIN_USER_PASSWORD}" ]; then
     fi
 fi
 
-echo_info "Wait for SonarQube to become responsive"
+echo_info "Wait for SonarQube to become responsive ..."
 set +e
 n=0
 httpOk=
 until [ $n -ge 20 ]; do
     httpOk=$(curl ${INSECURE} -sS -o /dev/null -w "%{http_code}" "${SONARQUBE_URL}/api/server/version")
     if [ "${httpOk}" == "200" ]; then
-        echo_info "SonarQube is up"
+        echo_info "SonarQube is up."
         break
     else
         echo_info "SonarQube is not up yet, waiting 10s ..."
@@ -131,31 +144,49 @@ if [ "${httpOk}" != "200" ]; then
     exit 1
 fi
 
-echo_info "Checking if '${ADMIN_USER_NAME}' uses default password '${ADMIN_USER_DEFAULT_PASSWORD}'"
-if curl ${INSECURE} -X POST -sSf \
+echo_info "Checking if '${ADMIN_USER_NAME}' uses default password '${ADMIN_USER_DEFAULT_PASSWORD}'."
+if curl ${INSECURE} -X POST -sf \
     "${SONARQUBE_URL}/api/authentication/login?login=${ADMIN_USER_NAME}&password=${ADMIN_USER_DEFAULT_PASSWORD}"; then
-    echo_info "Default password '${ADMIN_USER_DEFAULT_PASSWORD}' is used, updating it now."
+    echo_info "Default password '${ADMIN_USER_DEFAULT_PASSWORD}' is used, changing password for '${ADMIN_USER_NAME}' now."
     if ! curl ${INSECURE} -X POST -sSf --user "${ADMIN_USER_NAME}:${ADMIN_USER_NAME}" \
         "${SONARQUBE_URL}/api/users/change_password?login=${ADMIN_USER_NAME}&password=${ADMIN_USER_PASSWORD}&previousPassword=${ADMIN_USER_DEFAULT_PASSWORD}"; then
         echo_error "Could not change default password of '${ADMIN_USER_NAME}'."
         exit 1
     fi
+    echo_info "Default password for '${ADMIN_USER_NAME}' changed."
     base64Password=$(echo -n "${ADMIN_USER_PASSWORD}" | base64)
-    echo_info "Base64-encoded password to use for 'SONAR_ADMIN_PASSWORD_B64': ${base64Password}"
-    echo_info "Default password changed"
+
+    if [ -z "${WRITE_TO_CONFIG}" ]; then
+        writeToConfigDefault="y"
+        read -r -e -p "Write '${ADMIN_USER_NAME}' password to ods-core.env? [${writeToConfigDefault}]: " input
+        if [ -z "${input}" ]; then
+            WRITE_TO_CONFIG=${writeToConfigDefault}
+        else
+            WRITE_TO_CONFIG=${input:-""}
+        fi
+    fi
+    if [ "${WRITE_TO_CONFIG}" == "y" ]; then
+        echo_info "Writing SONAR_ADMIN_PASSWORD_B64=${base64Password} into ods-core.env ..."
+        sed -ie "s|SONAR_ADMIN_PASSWORD_B64=.*$|SONAR_ADMIN_PASSWORD_B64=${base64Password}|g" "${ODS_CONFIGURATION_DIR}/ods-core.env"
+        VALUES_WRITTEN_TO_CONFIG="y"
+        echo_info "Value of 'SONAR_ADMIN_PASSWORD_B64' changed."
+    else
+        echo_warn "'${ADMIN_USER_NAME}' password changed, but not written to the config."
+        echo_warn "Base64-encoded password to use for 'SONAR_ADMIN_PASSWORD_B64': ${base64Password}"
+    fi
 else
-    echo_info "Default password is not in use."
+    echo_info "Default '${ADMIN_USER_NAME}' password is not in use."
 fi
 
-echo_info "Setting sonar.forceAuthentication=true"
+echo_info "Setting sonar.forceAuthentication=true ..."
 if ! curl ${INSECURE} -X POST -sSf --user "${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD}" \
     "${SONARQUBE_URL}/api/settings/set?key=sonar.forceAuthentication&value=true"; then
     echo_error "Could not enable sonar.forceAuthentication."
     exit 1
 fi
-echo_info "sonar.forceAuthentication is enabled"
+echo_info "sonar.forceAuthentication is enabled."
 
-echo_info "Checking if '${PIPELINE_USER_NAME}' exists"
+echo_info "Checking if '${PIPELINE_USER_NAME}' exists ..."
 if curl ${INSECURE} -X POST -sSf --user "${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD}" \
     "${SONARQUBE_URL}/api/users/search?q=${PIPELINE_USER_NAME}" | grep '"users":\[\]' >/dev/null; then
     echo_info "No user '${PIPELINE_USER_NAME}' present yet."
@@ -164,35 +195,62 @@ if curl ${INSECURE} -X POST -sSf --user "${ADMIN_USER_NAME}:${ADMIN_USER_PASSWOR
         read -r -e -s input
         PIPELINE_USER_PWD=${input:-""}
     fi
-    echo_info "Trying to login in with '${PIPELINE_USER_NAME}'"
+    echo_info "Trying to login in with '${PIPELINE_USER_NAME}' ..."
     if ! curl ${INSECURE} -X POST -sSf \
         "${SONARQUBE_URL}/api/authentication/login?login=${PIPELINE_USER_NAME}&password=${PIPELINE_USER_PWD}"; then
         echo_error "Could not login with '${PIPELINE_USER_NAME}'."
         exit 1
     fi
-    echo_info "User token created"
+    echo_info "Login for '${PIPELINE_USER_NAME}' successful."
 fi
-echo_info "User '${PIPELINE_USER_NAME}' exists in SonarQube"
+echo_info "User '${PIPELINE_USER_NAME}' exists in SonarQube."
 
-echo_info "Checking if there are already tokens for '${PIPELINE_USER_NAME}'"
-if ! curl ${INSECURE} -sSf --user "${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD}" \
-    "${SONARQUBE_URL}/api/user_tokens/search?login=${PIPELINE_USER_NAME}" | grep '"userTokens":\[\]' >/dev/null; then
-    echo_info "There are already token(s) for '${PIPELINE_USER_NAME}'."
+sampleToken=$(grep SONAR_AUTH_TOKEN_B64 "${ODS_CORE_DIR}/configuration-sample/ods-core.env.sample" | cut -d "=" -f 2-)
+configuredToken=$(grep SONAR_AUTH_TOKEN_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2- | base64 --decode)
+authTokenVerified=""
+if [ "${configuredToken}" == "${sampleToken}" ]; then
+    echo_info "Auth token in ods-core.env is the sample value."
 else
-    echo_info "Creating token for '${PIPELINE_USER_NAME}'."
+    echo_info "Checking if login with token from ods-core.env is possible ..."
+    if curl ${INSECURE} -sSf --user "${configuredToken}": "${SONARQUBE_URL}/api/user_tokens/search?login=cd_user" > /dev/null; then
+        echo_info "Configured token for '${PIPELINE_USER_NAME}' verified."
+        authTokenVerified="y"
+    fi
+fi
+
+if [ -z "${authTokenVerified}" ]; then
+    echo_info "Creating token for '${PIPELINE_USER_NAME}' ..."
     tokenResponse=$(curl ${INSECURE} -X POST -sSf --user "${ADMIN_USER_NAME}:${ADMIN_USER_PASSWORD}" \
         "${SONARQUBE_URL}/api/user_tokens/generate?login=${PIPELINE_USER_NAME}&name=${TOKEN_NAME}")
+    echo_info "Created token for '${PIPELINE_USER_NAME}'."
     # Example response:
     # {"login":"cd_user","name":"foo","token":"bar","createdAt":"2020-04-22T13:21:54+0000"}
     token=$(echo "${tokenResponse}" | jq -r .token)
-    echo_info "Created token: ${token}"
     base64Token=$(echo -n "${token}" | base64)
-    echo_info "Base64-encoded token to use for 'SONAR_AUTH_TOKEN_B64': ${base64Token}"
 
-    echo "${base64Token}" > /tmp/sq_token_base64
-    echo "${token}" > /tmp/sq_token
+    if [ -z "${WRITE_TO_CONFIG}" ]; then
+        writeToConfigDefault="y"
+        read -r -e -p "Write token to ods-core.env? [${writeToConfigDefault}]: " input
+        if [ -z "${input}" ]; then
+            WRITE_TO_CONFIG=${writeToConfigDefault}
+        else
+            WRITE_TO_CONFIG=${input:-""}
+        fi
+    fi
+    if [ "${WRITE_TO_CONFIG}" == "y" ]; then
+        echo_info "Writing SONAR_AUTH_TOKEN_B64=${base64Token} into ods-core.env ..."
+        sed -ie "s|SONAR_AUTH_TOKEN_B64=.*$|SONAR_AUTH_TOKEN_B64=${base64Token}|g" "${ODS_CONFIGURATION_DIR}/ods-core.env"
+        echo_info "Value of 'SONAR_AUTH_TOKEN_B64' changed."
+        VALUES_WRITTEN_TO_CONFIG="y"
+    else
+        echo_warn "Auth token created, but not written to the config."
+        echo_warn "Base64-encoded token to use for 'SONAR_AUTH_TOKEN_B64': ${base64Token}"
+    fi
 fi
 
-echo "If configuration needs to be updated, please add the base64 encoded token and the admin password into ods-core.env."
+if [ -n "${VALUES_WRITTEN_TO_CONFIG}" ]; then
+    echo_warn "Some values in '${ODS_CONFIGURATION_DIR}/ods-core.env' have been updated."
+    echo_warn "Commit and push the changes to Bitbucket."
+fi
 
-echo_done "SonarQube configured"
+echo_done "SonarQube configured."


### PR DESCRIPTION
Replaces approach in #622.

Closes #624. 

@georgfedermann Could you verify that this works for you? You'd need to update your script slightly (to not read from `/tmp*` and instead pass `--write-to-config` to `./configure`). Maybe you can cherry-pick the commit from this PR into your branch, make the required changes, run it once and provide feedback if this works out for you?