### PR TITLE
aim to limit restarts of nexus

### DIFF
--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -188,7 +188,10 @@ function changeScriptSetting {
     fi
 }
 
-# changeScriptSetting does not require server to be up.
+# In the local context changeScriptSetting works directly after docker run
+if [ -z "${LOCAL_CONTAINER_ID}" ]; then
+    waitForReady
+fi
 changeScriptSetting "true"
 
 waitForReady

--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -188,8 +188,7 @@ function changeScriptSetting {
     fi
 }
 
-waitForReady
-
+# changeScriptSetting does not require server to be up.
 changeScriptSetting "true"
 
 waitForReady
@@ -264,6 +263,10 @@ sed "s|@developer_password@|${DEVELOPER_PASSWORD}|g" json/developer-user.json > 
 runJsonScript "createUser" "-d @json/developer-user-with-password.json"
 rm json/developer-user-with-password.json
 
-changeScriptSetting "false"
+if [ -z "${LOCAL_CONTAINER_ID}" ]; then
+    changeScriptSetting "false"
+    waitForReady
+else
+    true # on local docker nexus don't care about security
+fi
 
-waitForReady


### PR DESCRIPTION
Clemens asked me to look into reducing the number of restarts.
If the statements below are correct this should be mergeable. 

When nexus runs externally we assume there is no initial wait needed.

With docker:
- Changing the ScriptSettings can be done without requiring the server to be up.
- There should be no need to set the script setting to false again.
- This results in only one time waiting for the local case.