### PR TITLE
Fix Jenkins master issues 

### DIFF
--- a/jenkins/master/configuration/init.groovy.d/proxy.groovy
+++ b/jenkins/master/configuration/init.groovy.d/proxy.groovy
@@ -6,14 +6,14 @@ Jenkins jenkins = Jenkins.getInstance()
 String httpProxy = System.getenv('HTTP_PROXY')
 
 if (!httpProxy) {
-  println("No proxy config found - returning..")
+  println("No proxy config found")
   return
 }
 
 if (jenkins.proxy) {
-  println("Proxy ALREADY set to: ${jenkins.proxy.name}:${jenkins.proxy.port} - leaving ..")
+  println("Proxy ALREADY set to: ${jenkins.proxy.name}:${jenkins.proxy.port}")
   return
-} 
+}
 
 httpProxy = httpProxy.minus(~/^https?:\/\//)
 println (httpProxy)
@@ -25,12 +25,14 @@ String noProxyAmended = httpNOProxyHosts.replace(',','\r')
 ProxyConfiguration proxy
 
 if (httpProxySplit.size() == 2) {
-    proxy = new ProxyConfiguration(
-        httpProxySplit[0], httpProxySplit[1] as int, null, null, noProxyAmended) 
+  proxy = new ProxyConfiguration(
+    httpProxySplit[0], httpProxySplit[1] as int, null, null, noProxyAmended
+  )
 } else {
-    proxy = new ProxyConfiguration(
-        httpProxySplit[0], 80, null, null, noProxyAmended) 
-}   
+  proxy = new ProxyConfiguration(
+    httpProxySplit[0], 80, null, null, noProxyAmended
+  )
+}
 
 jenkins.proxy = proxy
 

--- a/jenkins/master/configuration/init.groovy.d/url.groovy
+++ b/jenkins/master/configuration/init.groovy.d/url.groovy
@@ -2,7 +2,7 @@ import jenkins.model.JenkinsLocationConfiguration
 def jlc = jenkins.model.JenkinsLocationConfiguration.get()
 def namespace = "cat /var/run/secrets/kubernetes.io/serviceaccount/namespace".execute().text.trim()
 println "INFO: JenkinsLocationConfiguration - namespace of pod is: ${namespace}"
-def url = "oc get route jenkins -n ${namespace} --template 'http{{if .spec.tls}}s{{end}}://{{.spec.host}}'".execute().text.trim()
+def url = "oc get route jenkins -n ${namespace} --template http{{if.spec.tls}}s{{end}}://{{.spec.host}}".execute().text.trim()
 println "INFO: JenkinsLocationConfiguration - URL to Jenkins is: ${url}"
 jlc.setUrl(url)
 jlc.save()

--- a/jenkins/master/ods-run
+++ b/jenkins/master/ods-run
@@ -50,5 +50,45 @@ sed -i.bak -e "s|__NEXUS_HOST|$nexusUrl|g" $HOME/.groovy/grapeConfig.xml
 sed -i.bak -e "s|__NEXUS_USER|$NEXUS_USERNAME|g" $HOME/.groovy/grapeConfig.xml
 sed -i.bak -e "s|__NEXUS_PW|$NEXUS_PASSWORD|g" $HOME/.groovy/grapeConfig.xml
 
+if [ -e "${JENKINS_HOME}/plugins" ]; then
+  # RHEL base images install plugins (defined in the yum package jenkins-2-plugins)
+  # as *.hpi files via yum into /usr/lib/jenkins, and create a symlink from
+  # /opt/openshift/plugins to the actual files at /usr/lib/jenkins.
+  # During boot (contrib/s2i/run) a symlink is created for any plugins existing at
+  # /usr/lib/jenkins but not in /var/lib/jenkins/plugins. This makes Jenkins
+  # "see" and use the plugin.
+
+  # CentOS base images install plugins (defined in /opt/openshift/base-plugins.txt)
+  # as *.jpi files via /usr/local/bin/install-plugins.sh into /opt/openshift/plugins.
+
+  # For both RHEL and CentOS, if there are plugins at /opt/openshift/plugins,
+  # those are copied to /var/lib/jenkins/plugins on initial boot (or if
+  # OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS is set). For RHEL, this means copied plugins
+  # loose the symlinked nature, for CentOS no links are in place anyway.
+
+  # As ODS maintainers, we want to ensure that all plugins managed by either OpenShift
+  # or added by us are always in the versions that we specify. We must ensure that
+  # we can update plugins when we publish a new image. On the other hand, we want to
+  # prevent manual plugin updates as we cannot guarantee that newer versions will work.
+  # Further, in a regulated environment, the combination of plugins defined by ODS is
+  # validated, so should not be modified by users anyway.
+
+  # To achieve this, we copy all plugins at /opt/openshift/plugins
+  # to /var/lib/jenkins/plugins during boot. RHEL then thinks we "manage the version", but
+  # in fact we just copy the version defined by them - and since we do this on every boot,
+  # it has the same effect that the symlinks would have.
+  echo "Enforcing plugin versions defined in the image ..."
+  if [ "$(ls /opt/openshift/plugins/* 2>/dev/null)" ]; then
+    echo "Copying $(ls /opt/openshift/plugins/* | wc -l) files to ${JENKINS_HOME} ..."
+    for FILENAME in /opt/openshift/plugins/* ; do
+      # also need to nuke the metadir; it will get properly populated on jenkins startup
+      basefilename=`basename $FILENAME .jpi`
+      rm -rf "${JENKINS_HOME}/plugins/${basefilename}"
+      cp --remove-destination $FILENAME ${JENKINS_HOME}/plugins
+    done
+    rm -rf /opt/openshift/plugins
+  fi
+fi
+
 echo "Booting Jenkins ..."
 /usr/libexec/s2i/run

--- a/jenkins/master/ods-run
+++ b/jenkins/master/ods-run
@@ -30,7 +30,7 @@ if [ -d "$target_init_groovy_dir" ] ; then
         cp "${source_init_groovy_dir}/${fileName}" "${target_init_groovy_dir}/${fileName}"
     done
     echo "Remove legacy init.groovy.d files ..."
-    rm "${target_init_groovy_dir}/ods-mro-jenkins-shared-library.groovy" || true
+    rm "${target_init_groovy_dir}/ods-mro-jenkins-shared-library.groovy" &> /dev/null || true
 fi
 
 echo "Copy grape config and amending with Nexus ..."

--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -1,11 +1,5 @@
-token-macro:2.3
 greenballs:1.15
-credentials-binding:1.18
-email-ext:2.63
+email-ext:2.69
 sonar:2.6.1
-ansicolor:0.5.2
-workflow-cps-global-lib:2.13
-junit:1.28
+ansicolor:0.7.0
 blueocean:1.18.0
-workflow-durable-task-step:2.28
-openshift-sync:1.0.44


### PR DESCRIPTION
Fixes #670 by ensuring that all plugins defined by the RedHat-provided base image are actually deployed in the version defined there. Previously, some plugins would not have been updated in older Jenkins instances (because the plugins on the volume were not symlinked, but overwritten by our `plugins.txt`).

Fixes #411 by copying all plugins either defined in the RedHat-provided base image (see above) OR installed via our `plugins.txt` to the volume on every subsequent Jenkins boot. As a consequence, users of ODS cannot change the plugin versions for those plugins long-term. Every container boot resets the plugin version.

Also, it fixes a bug introduced by #684, as Groovy is tripped up by the space in the command line argument. Luckily, Go templates also work without a space between `if .spec.tls`.

And finally, it removes a bunch of plugins from `plugins.txt` that are anyway provided by the base image. Only exception is `blueocean`, which is actually provided in version 1.10. However, we need a newer version, so we define 1.18 in our `plugins.txt` (and that is the version which actually gets installed).

To test this, I've updated several Jenkins instances in various states (2.176, 2.204, 2.222) as well as updating some plugins manually and restarting. I hope that I covered all edge cases but this whole thing is very brittle and once RedHat ships new base images we need to verify everything again :(

PR replaces #672. 