### PR TITLE
Update existing pipeline if jenkinsfilePath or branch differ

### DIFF
--- a/jenkins/webhook-proxy/pipeline.json.tmpl
+++ b/jenkins/webhook-proxy/pipeline.json.tmpl
@@ -3,7 +3,8 @@
     "apiVersion": "v1",
     "metadata": {
         "name": "{{.Name}}",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "resourceVersion": "{{.ResourceVersion}}"
     },
     "spec": {
         "triggers": [

--- a/jenkins/webhook-proxy/test/fixtures/build-pipeline-branch.json
+++ b/jenkins/webhook-proxy/test/fixtures/build-pipeline-branch.json
@@ -2,9 +2,9 @@
     "kind": "BuildConfig",
     "apiVersion": "v1",
     "metadata": {
-        "name": "ods-provisioning-app-production",
+        "name": "repository-foo",
         "creationTimestamp": null,
-        "resourceVersion": "0"
+        "resourceVersion": "42"
     },
     "spec": {
         "triggers": [
@@ -20,8 +20,8 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://domain.com/foo/ods-provisioning-app.git",
-                "ref": "production"
+                "uri": "https://domain.com/bar/repository.git",
+                "ref": "bar"
             },
             "sourceSecret": {
                 "name": "cd-user-with-password"
@@ -31,7 +31,7 @@
             "type": "JenkinsPipeline",
             "jenkinsPipelineStrategy": {
                 "jenkinsfilePath": "Jenkinsfile",
-                "env": null
+                "env": [{"name":"FOO_BAR","value":"baz"}]
             }
         },
         "output": {},

--- a/jenkins/webhook-proxy/test/fixtures/build-pipeline-jenkinsfilepath.json
+++ b/jenkins/webhook-proxy/test/fixtures/build-pipeline-jenkinsfilepath.json
@@ -2,9 +2,9 @@
     "kind": "BuildConfig",
     "apiVersion": "v1",
     "metadata": {
-        "name": "ods-provisioning-app-production",
+        "name": "repository-foo",
         "creationTimestamp": null,
-        "resourceVersion": "0"
+        "resourceVersion": "42"
     },
     "spec": {
         "triggers": [
@@ -20,8 +20,8 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://domain.com/foo/ods-provisioning-app.git",
-                "ref": "production"
+                "uri": "https://domain.com/bar/repository.git",
+                "ref": "foo"
             },
             "sourceSecret": {
                 "name": "cd-user-with-password"
@@ -30,8 +30,8 @@
         "strategy": {
             "type": "JenkinsPipeline",
             "jenkinsPipelineStrategy": {
-                "jenkinsfilePath": "Jenkinsfile",
-                "env": null
+                "jenkinsfilePath": "foo/Jenkinsfile",
+                "env": [{"name":"FOO_BAR","value":"baz"}]
             }
         },
         "output": {},

--- a/jenkins/webhook-proxy/test/golden/build-component-pipeline.json
+++ b/jenkins/webhook-proxy/test/golden/build-component-pipeline.json
@@ -3,7 +3,8 @@
     "apiVersion": "v1",
     "metadata": {
         "name": "baz-foo",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "resourceVersion": "0"
     },
     "spec": {
         "triggers": [

--- a/jenkins/webhook-proxy/test/golden/build-pipeline-branch.json
+++ b/jenkins/webhook-proxy/test/golden/build-pipeline-branch.json
@@ -2,9 +2,9 @@
     "kind": "BuildConfig",
     "apiVersion": "v1",
     "metadata": {
-        "name": "ods-provisioning-app-production",
+        "name": "repository-foo",
         "creationTimestamp": null,
-        "resourceVersion": "0"
+        "resourceVersion": "42"
     },
     "spec": {
         "triggers": [
@@ -20,8 +20,8 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://domain.com/foo/ods-provisioning-app.git",
-                "ref": "production"
+                "uri": "https://domain.com/bar/repository.git",
+                "ref": "foo"
             },
             "sourceSecret": {
                 "name": "cd-user-with-password"
@@ -31,7 +31,7 @@
             "type": "JenkinsPipeline",
             "jenkinsPipelineStrategy": {
                 "jenkinsfilePath": "Jenkinsfile",
-                "env": null
+                "env": [{"name":"FOO_BAR","value":"baz"}]
             }
         },
         "output": {},

--- a/jenkins/webhook-proxy/test/golden/build-pipeline-jenkinsfilepath.json
+++ b/jenkins/webhook-proxy/test/golden/build-pipeline-jenkinsfilepath.json
@@ -2,9 +2,9 @@
     "kind": "BuildConfig",
     "apiVersion": "v1",
     "metadata": {
-        "name": "ods-provisioning-app-production",
+        "name": "repository-foo",
         "creationTimestamp": null,
-        "resourceVersion": "0"
+        "resourceVersion": "42"
     },
     "spec": {
         "triggers": [
@@ -20,8 +20,8 @@
         "source": {
             "type": "Git",
             "git": {
-                "uri": "https://domain.com/foo/ods-provisioning-app.git",
-                "ref": "production"
+                "uri": "https://domain.com/bar/repository.git",
+                "ref": "foo"
             },
             "sourceSecret": {
                 "name": "cd-user-with-password"
@@ -30,8 +30,8 @@
         "strategy": {
             "type": "JenkinsPipeline",
             "jenkinsPipelineStrategy": {
-                "jenkinsfilePath": "Jenkinsfile",
-                "env": null
+                "jenkinsfilePath": "bar/Jenkinsfile",
+                "env": [{"name":"FOO_BAR","value":"baz"}]
             }
         },
         "output": {},

--- a/jenkins/webhook-proxy/test/golden/build-pipeline.json
+++ b/jenkins/webhook-proxy/test/golden/build-pipeline.json
@@ -3,7 +3,8 @@
     "apiVersion": "v1",
     "metadata": {
         "name": "repository-foo",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "resourceVersion": "0"
     },
     "spec": {
         "triggers": [

--- a/jenkins/webhook-proxy/test/golden/pipeline.json
+++ b/jenkins/webhook-proxy/test/golden/pipeline.json
@@ -3,7 +3,8 @@
     "apiVersion": "v1",
     "metadata": {
         "name": "repository-master",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "resourceVersion": "0"
     },
     "spec": {
         "triggers": [

--- a/jenkins/webhook-proxy/test/golden/prov-app-pipeline.json
+++ b/jenkins/webhook-proxy/test/golden/prov-app-pipeline.json
@@ -3,7 +3,8 @@
     "apiVersion": "v1",
     "metadata": {
         "name": "ods-provisioning-app-production",
-        "creationTimestamp": null
+        "creationTimestamp": null,
+        "resourceVersion": "0"
     },
     "spec": {
         "triggers": [


### PR DESCRIPTION
Fixes #710.
Fixes #226. Note that simultaneous branches are not possible now, but at
least each pipeline run should be executed with the correct branch.

The way the OpenShift API works, it was required to add the `resourceVersion` into the template to get `PUT` requests working.