### PR TITLE
Read ODS_NAMESPACE from config

### DIFF
--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -123,15 +123,13 @@ git push -u origin master
 
 === Central ODS project
 
-OpenDevStack needs one central `ods` project in OpenShift, which will hold all shared resources such as images or deployments.
+OpenDevStack needs one central project in OpenShift, which will hold all shared resources such as images or deployments. This project is typically called `ods`, but you can customize this in the configuration via `ODS_NAMESPACE`.
 
 In `ods-core` run:
 [source,sh]
 ----
 make install-ods-project
 ----
-
-TIP: In certain situations, you may want to pick a different name for the central namespace, e.g. for testing purposes or trying two versions of ODS next to each other. To do so, you need to run this and the following commands with `make NAMESPACE=foo <target>`.
 
 
 === Nexus

--- a/ods-setup/bitbucket.sh
+++ b/ods-setup/bitbucket.sh
@@ -24,7 +24,7 @@ echo_info(){
 BITBUCKET_URL=""
 BITBUCKET_USER=""
 BITBUCKET_PWD=""
-BITBUCKET_ODS_PROJECT="OPENDEVSTACK"
+BITBUCKET_ODS_PROJECT=""
 INSECURE=""
 
 function usage {
@@ -38,7 +38,7 @@ function usage {
     printf "\t-b|--bitbucket\t\tBitbucket URL, e.g. 'https://bitbucket.example.com'\n"
     printf "\t-u|--user\t\tBitbucket user\n"
     printf "\t-p|--password\t\tBitbucket password\n"
-    printf "\t-o|--ods-project\tName of OpenDevStack project (defaults to '%s')\n" "${BITBUCKET_ODS_PROJECT}"
+    printf "\t-o|--ods-project\tName of OpenDevStack project\n"
 }
 
 while [[ "$#" -gt 0 ]]; do
@@ -68,14 +68,26 @@ esac; shift; done
 if [ -z "${BITBUCKET_URL}" ]; then
     configuredUrl="https://bitbucket.example.com"
     if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
-        echo_info "Configuration located"
-        configuredUrl=$(grep BITBUCKET_URL "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
+        configuredUrl=$(../scripts/get-config-param.sh BITBUCKET_URL)
     fi
     read -r -e -p "Enter Bitbucket URL [${configuredUrl}]: " input
     if [ -z "${input}" ]; then
         BITBUCKET_URL=${configuredUrl}
     else
         BITBUCKET_URL="${input}"
+    fi
+fi
+
+if [ -z "${BITBUCKET_ODS_PROJECT}" ]; then
+    configuredProject="OPENDEVSTACK"
+    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
+        configuredProject=$(../scripts/get-config-param.sh ODS_BITBUCKET_PROJECT)
+    fi
+    read -r -e -p "Enter Bitbucket ODS Project [${configuredProject}]: " input
+    if [ -z "${input}" ]; then
+        BITBUCKET_ODS_PROJECT=${configuredProject}
+    else
+        BITBUCKET_ODS_PROJECT="${input}"
     fi
 fi
 

--- a/scripts/get-config-param.sh
+++ b/scripts/get-config-param.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Start build of given image and follows the output.
+# After build finishes, we verify status is "Complete".
+
+set -ue
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_CORE_DIR=${SCRIPT_DIR%/*}
+ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
+
+if [ ! -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
+    echo "Configuration could not be located at ${ODS_CONFIGURATION_DIR}/ods-core.env."
+    exit 1
+fi
+
+PARAM_NAME=${1:-""}
+
+if [ -z "${PARAM_NAME}" ]; then
+    echo "No param name given. Usage: $0 <PARAM-NAME>"
+    exit 1
+fi
+
+if ! grep "${PARAM_NAME}" "${ODS_CONFIGURATION_DIR}/ods-core.env" > /dev/null; then
+    echo "No param ${PARAM_NAME} found." 
+    exit 1
+fi
+
+grep "${PARAM_NAME}" "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-


### PR DESCRIPTION
It seems that the "multiple ODS installations in one cluster" use case is more prominent than we originally anticipated. To make usage of it easier, the `Makefile` targets now read the namespace from the config, which avoids having to pass the namespace all the time like `make NAMESPACE=abc install-jenkins`.

Further:
* extract reading a param value from the config into its own script so that it can easily be reused
* reading the Bitbucket Project from config as well

FYI @renedupont @segator pay attention to this when installing next time :)