### PR TITLE
Webhook Proxy config: set Bitbucket project explicitly

### DIFF
--- a/create-projects/Jenkinsfile
+++ b/create-projects/Jenkinsfile
@@ -95,6 +95,7 @@ podTemplate(
             --project=${projectId} \
             --ods-namespace=${odsNamespace} \
             --ods-image-tag=${odsImageTag} \
+            --ods-bitbucket-project ${odsBitbucketProject} \
             --pipeline-trigger-secret-b64=${pipelineTriggerSecret} \
             --cd-user-type=${cdUserType} \
             --cd-user-id-b64=${cdUserIdB64}""",

--- a/create-projects/create-cd-jenkins.sh
+++ b/create-projects/create-cd-jenkins.sh
@@ -13,6 +13,7 @@ set -eu
 TAILOR="tailor"
 ODS_NAMESPACE="ods"
 ODS_IMAGE_TAG="latest"
+ODS_BITBUCKET_PROJECT="opendevstack"
 PROJECT_ID=""
 CD_USER_TYPE=""
 CD_USER_ID_B64=""
@@ -28,6 +29,7 @@ function usage {
   printf "\t-p|--project\t\t\tProject ID\n"
   printf "\t--ods-namespace\t\t\tThe namespace where all ODS resources reside. Default: %s\n" "${ODS_NAMESPACE}"
   printf "\t--ods-image-tag\t\t\tThe image tag to use. Default: %s\n" "${ODS_IMAGE_TAG}"
+  printf "\t--ods-bitbucket-project\t\t\tThe Bitbucket project to use. Default: %s\n" "${ODS_BITBUCKET_PROJECT}"
   printf "\t--pipeline-trigger-secret-b64\tTrigger secret for pipelines (base64 encoded)\n"
   printf "\t--cd-user-type\t\t\tWhether CD user is general or project specific\n"
   printf "\t--cd-user-id-b64\t\tName of CD user (base64 encoded)\n"
@@ -51,6 +53,9 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 
   --ods-image-tag=*) ODS_IMAGE_TAG="${1#*=}";;
   --ods-image-tag)   ODS_IMAGE_TAG="$2"; shift;;
+
+  --ods-bitbucket-project=*) ODS_BITBUCKET_PROJECT="${1#*=}";;
+  --ods-bitbucket-project)   ODS_BITBUCKET_PROJECT="$2"; shift;;
 
   --pipeline-trigger-secret-b64=*) PIPELINE_TRIGGER_SECRET_B64="${1#*=}";;
   --pipeline-trigger-secret-b64)   PIPELINE_TRIGGER_SECRET_B64="$2"; shift;;
@@ -112,5 +117,6 @@ ${TAILOR} ${TAILOR_VERBOSE} ${TAILOR_NON_INTERACTIVE} apply \
   "--param=CD_USER_ID_B64=${CD_USER_ID_B64}" \
   "--param=ODS_NAMESPACE=${ODS_NAMESPACE}" \
   "--param=ODS_IMAGE_TAG=${ODS_IMAGE_TAG}" \
+  "--param=ODS_BITBUCKET_PROJECT=${ODS_BITBUCKET_PROJECT}" \
   "${cdUserPwdParam}" \
   --selector "template=ods-jenkins-template"

--- a/create-projects/tests/run.sh
+++ b/create-projects/tests/run.sh
@@ -113,13 +113,14 @@ echo "=== create-cd-jenkins: With general CD user ==="
 
 tailor mock --receive='version' --stdout='1.1.3'
 
-tailor mock --receive='--non-interactive apply --namespace=foo-cd --param=PIPELINE_TRIGGER_SECRET_B64=czNjcjN0 --param=PROJECT=foo --param=CD_USER_ID_B64=Y2RfdXNlcg== --param=ODS_NAMESPACE=bar --param=ODS_IMAGE_TAG=3.x --selector template=ods-jenkins-template' --times 1
+tailor mock --receive='--non-interactive apply --namespace=foo-cd --param=PIPELINE_TRIGGER_SECRET_B64=czNjcjN0 --param=PROJECT=foo --param=CD_USER_ID_B64=Y2RfdXNlcg== --param=ODS_NAMESPACE=bar --param=ODS_IMAGE_TAG=3.x --param=ODS_BITBUCKET_PROJECT=opendevstack --selector template=ods-jenkins-template' --times 1
 
 ../create-cd-jenkins.sh \
     --project foo \
     --non-interactive \
     --ods-namespace=bar \
     --ods-image-tag=3.x \
+    --ods-bitbucket-project=opendevstack \
     --pipeline-trigger-secret-b64=$(echo -n "s3cr3t" | base64) \
     --cd-user-type=general \
     --cd-user-id-b64=$(echo -n "cd_user" | base64) \
@@ -131,13 +132,14 @@ echo "=== create-cd-jenkins: With project-specific CD user ==="
 
 tailor mock --receive='version' --stdout='1.1.3'
 
-tailor mock --receive='--non-interactive apply --namespace=foo-cd --param=PIPELINE_TRIGGER_SECRET_B64=czNjcjN0 --param=PROJECT=foo --param=CD_USER_ID_B64=Zm9v --param=ODS_NAMESPACE=bar --param=ODS_IMAGE_TAG=3.x --param=CD_USER_PWD_B64=Y2hhbmdlbWU= --selector template=ods-jenkins-template' --times 1
+tailor mock --receive='--non-interactive apply --namespace=foo-cd --param=PIPELINE_TRIGGER_SECRET_B64=czNjcjN0 --param=PROJECT=foo --param=CD_USER_ID_B64=Zm9v --param=ODS_NAMESPACE=bar --param=ODS_IMAGE_TAG=3.x --param=ODS_BITBUCKET_PROJECT=opendevstack --param=CD_USER_PWD_B64=Y2hhbmdlbWU= --selector template=ods-jenkins-template' --times 1
 
 ../create-cd-jenkins.sh \
     --project foo \
     --non-interactive \
     --ods-namespace=bar \
     --ods-image-tag=3.x \
+    --ods-bitbucket-project=opendevstack \
     --pipeline-trigger-secret-b64=$(echo -n "s3cr3t" | base64) \
     --cd-user-type=specific \
     --cd-user-id-b64=$(echo -n "foo" | base64) \

--- a/jenkins/ocp-config/deploy/jenkins-webhook-proxy.yml
+++ b/jenkins/ocp-config/deploy/jenkins-webhook-proxy.yml
@@ -18,6 +18,8 @@ parameters:
   required: true
 - name: PIPELINE_TRIGGER_SECRET_B64
   required: true
+- name: ODS_BITBUCKET_PROJECT
+  required: true
 - name: WEBHOOK_PROXY_CPU_REQUEST
   value: 50m
 - name: WEBHOOK_PROXY_CPU_LIMIT
@@ -91,7 +93,9 @@ objects:
         containers:
         - env:
           - name: REPO_BASE
-            value: '${REPO_BASE}'
+            value: ${REPO_BASE}
+          - name: ALLOWED_EXTERNAL_PROJECTS
+            value: ${ODS_BITBUCKET_PROJECT}
           - name: TRIGGER_SECRET
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Otherwise, manual configuration will be needed to provision quickstarters
from central namespaces which do not use sources from the OPENDEVSTACK
project.