### PR TITLE
Add workflow-durable-task-step:2.35

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -3,3 +3,4 @@ email-ext:2.69
 sonar:2.6.1
 ansicolor:0.7.0
 blueocean:1.18.0
+workflow-durable-task-step:2.35


### PR DESCRIPTION
This plugin is actually present in this version in the base image definition, but the Centos image hasn't been updated in Docker Hub (see https://github.com/openshift/jenkins/issues/1109). Of course this should be fixed upstream, but to bypass issues we have right now, we fix that problem here for ODS 3.0. Once the image has been updated in Docker Hub, we can remove the plugin again.

Fixes #732 (v2.28 of the plugin added the required functionality, see https://github.com/jenkinsci/workflow-durable-task-step-plugin/blob/master/CHANGELOG.md#228).