### PR TITLE
Revert "Add workflow-durable-task-step:2.35"

### DIFF
--- a/jenkins/master/plugins.txt
+++ b/jenkins/master/plugins.txt
@@ -3,4 +3,3 @@ email-ext:2.69
 sonar:2.6.1
 ansicolor:0.7.0
 blueocean:1.18.0
-workflow-durable-task-step:2.35


### PR DESCRIPTION
Reverts opendevstack/ods-core#733

Apparently that screws up something (maybe incompatibility with other plugins?)