### PR TITLE
Set memory request to realistic value

### DIFF
--- a/jenkins/ocp-config/deploy/jenkins-master.yml
+++ b/jenkins/ocp-config/deploy/jenkins-master.yml
@@ -19,7 +19,7 @@ parameters:
 - name: JENKINS_MEMORY_LIMIT
   value: 5Gi
 - name: JENKINS_MEMORY_REQUEST
-  value: 2560Mi
+  value: 4Gi
 - name: JENKINS_CPU_LIMIT
   value: "1"
 - name: JENKINS_CPU_REQUEST


### PR DESCRIPTION
4Gi seems to be roughly what is actually used by Jenkins.

Closes #748.