### PR TITLE
Add BuildConfig and fix retrieval of proxy vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,19 +138,29 @@ configure-sonarqube:
 
 # NEXUS
 ## Install or update Nexus.
-install-nexus: apply-nexus
+install-nexus: apply-nexus-build start-nexus-build apply-nexus-deploy
 .PHONY: nexus
 
+## Update OpenShift resources related to the Nexus image.
+apply-nexus-build:
+	cd nexus/ocp-config && tailor apply --namespace $(ODS_NAMESPACE) bc,is
+.PHONY: apply-nexus-build
+
+## Start build of BuildConfig "nexus".
+start-nexus-build:
+	ocp-scripts/start-and-follow-build.sh --namespace $(ODS_NAMESPACE) --build-config nexus
+.PHONY: start-nexus-build
+
 ## Update OpenShift resources related to the Nexus service.
-apply-nexus:
-	cd nexus/ocp-config && tailor apply --namespace $(ODS_NAMESPACE)
-.PHONY: apply-nexus
+apply-nexus-deploy:
+	cd nexus/ocp-config && tailor apply --namespace $(ODS_NAMESPACE) --exclude bc,is
+.PHONY: apply-nexus-deploy
 
 ## Configure Nexus service.
 configure-nexus:
 	cd nexus && ./configure.sh --namespace $(ODS_NAMESPACE) --nexus=$(NEXUS_URL)
 .PHONY: configure-nexus
-### Not part of install-nexus because it is not idempotent yet.
+### configure-nexus is not part of install-nexus because it is not idempotent yet.
 
 
 # BACKUP

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -26,7 +26,10 @@ ODS_BITBUCKET_PROJECT=opendevstack
 # Nexus #
 #########
 
-# Note that only the the version defined in nexus/ocp-config/dc.yml is supported officially.
+# Nexus base image
+# See https://hub.docker.com/r/sonatype/nexus3/tags.
+# Note that only 3.23.0 is supported officially.
+NEXUS_FROM_IMAGE=sonatype/nexus3:3.23.0
 
 # Nexus host without protocol.
 # The domain should be equal to OPENSHIFT_APPS_BASEDOMAIN (see below).

--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -200,9 +200,9 @@ waitForReady
 DEFAULT_ADMIN_PASSWORD_FILE="/nexus-data/admin.password"
 if [ -z "${LOCAL_CONTAINER_ID}" ]; then
     ADMIN_DEFAULT_PASSWORD=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "cat ${DEFAULT_ADMIN_PASSWORD_FILE} 2> /dev/null || true")
-    HTTP_PROXY=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "echo -n $HTTP_PROXY")
-    HTTPS_PROXY=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "echo -n $HTTPS_PROXY")
-    NO_PROXY=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "echo -n $NO_PROXY")
+    HTTP_PROXY=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "echo -n \$HTTP_PROXY")
+    HTTPS_PROXY=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "echo -n \$HTTPS_PROXY")
+    NO_PROXY=$(oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" sh -c "echo -n \$NO_PROXY")
 else
     ADMIN_DEFAULT_PASSWORD=$(docker exec -t "${LOCAL_CONTAINER_ID}" sh -c "cat ${DEFAULT_ADMIN_PASSWORD_FILE} 2> /dev/null || true")
     # shellcheck disable=SC2046,SC2005

--- a/nexus/docker/Dockerfile
+++ b/nexus/docker/Dockerfile
@@ -1,0 +1,2 @@
+# FROM instruction is overwritten with NEXUS_FROM_IMAGE.
+FROM sonatype/nexus3:latest

--- a/nexus/ocp-config/bc.yml
+++ b/nexus/ocp-config/bc.yml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Template
+parameters:
+- name: ODS_BITBUCKET_PROJECT
+  value: opendevstack
+- name: ODS_IMAGE_TAG
+  required: true
+- name: ODS_GIT_REF
+  required: true
+- name: REPO_BASE
+  required: true
+- name: NEXUS_FROM_IMAGE
+  required: true
+- name: NEXUS_BUILD_CPU_REQUEST
+  value: 200m
+- name: NEXUS_BUILD_CPU_LIMIT
+  value: "1"
+- name: NEXUS_BUILD_MEMORY_REQUEST
+  value: 1Gi
+- name: NEXUS_BUILD_MEMORY_LIMIT
+  value: 2Gi
+objects:
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: nexus
+    name: nexus
+  spec:
+    failedBuildsHistoryLimit: 5
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: nexus:${ODS_IMAGE_TAG}
+    postCommit: {}
+    resources:
+      limits:
+        cpu: ${NEXUS_BUILD_CPU_LIMIT}
+        memory: ${NEXUS_BUILD_MEMORY_LIMIT}
+      requests:
+        cpu: ${NEXUS_BUILD_CPU_REQUEST}
+        memory: ${NEXUS_BUILD_MEMORY_REQUEST}
+    runPolicy: Serial
+    source:
+      contextDir: nexus/docker
+      git:
+        uri: ${REPO_BASE}/${ODS_BITBUCKET_PROJECT}/ods-core.git
+        ref: ${ODS_GIT_REF}
+      sourceSecret:
+        name: cd-user-token
+      type: Git
+    strategy:
+      dockerStrategy:
+        forcePull: true
+        noCache: true
+        from:
+          kind: DockerImage
+          name: ${NEXUS_FROM_IMAGE}
+      type: Docker
+    successfulBuildsHistoryLimit: 5
+    triggers: []

--- a/nexus/ocp-config/dc.yml
+++ b/nexus/ocp-config/dc.yml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Template
 parameters:
+- name: ODS_NAMESPACE
+  value: ods-next
+- name: ODS_IMAGE_TAG
+  required: true
 - name: NEXUS_NAME
   value: nexus
-- name: NEXUS_IMAGE
-  description: Image to use for Nexus
-  value: sonatype/nexus3:3.23.0
 - name: NEXUS_CPU_REQUEST
   value: 200m
 - name: NEXUS_CPU_LIMIT
@@ -40,7 +41,7 @@ objects:
           deploymentconfig: ${NEXUS_NAME}
       spec:
         containers:
-        - image: ${NEXUS_IMAGE}
+        - image: ${ODS_NAMESPACE}/${NEXUS_NAME}:${ODS_IMAGE_TAG}
           imagePullPolicy: Always
           name: ${NEXUS_NAME}
           ports:
@@ -74,4 +75,13 @@ objects:
             claimName: nexus-db-backup
     test: false
     triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NEXUS_NAME}
+        from:
+          kind: ImageStreamTag
+          name: ${NEXUS_NAME}:${ODS_IMAGE_TAG}
+          namespace: ${ODS_NAMESPACE}
+      type: ImageChange
     - type: ConfigChange

--- a/nexus/ocp-config/is.yml
+++ b/nexus/ocp-config/is.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Template
+objects:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: nexus
+    name: nexus
+  spec:
+    lookupPolicy:
+      local: false

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -368,7 +368,6 @@ objects:
       app: sonarqube
     name: sonarqube
   spec:
-    dockerImageRepository: sonarqube
     lookupPolicy:
       local: false
 - apiVersion: v1


### PR DESCRIPTION
Fixes #758.

If the dollar sign is not escaped, the shell command being executed is: `sh -c "echo -n "`, because the variables are set as empty strings at the beginning of the script.