### PR TITLE
Do not fail when default password removal returns exit code 129

### DIFF
--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -232,7 +232,7 @@ if [ -n "${ADMIN_DEFAULT_PASSWORD}" ]; then
     fi
     echo_info "Delete default admin password file"
     if [ -z "${LOCAL_CONTAINER_ID}" ]; then
-        oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" bash -c "rm ${DEFAULT_ADMIN_PASSWORD_FILE}"
+        oc -n "${NAMESPACE}" rsh "dc/${NEXUS_DC}" bash -c "rm ${DEFAULT_ADMIN_PASSWORD_FILE} || true"
     else
         docker exec -t "${LOCAL_CONTAINER_ID}" rm "${DEFAULT_ADMIN_PASSWORD_FILE}"
     fi


### PR DESCRIPTION
Sometimes (really?!) the command fails with exit code 129.
There is a bug that seems related at
https://bugzilla.redhat.com/show_bug.cgi?id=1517212.

FYI @clemensutschig @segator 