### PR TITLE
Do not fail when a DELETE request responds with 404

### DIFF
--- a/tests/scripts/provisioning-app-api.sh
+++ b/tests/scripts/provisioning-app-api.sh
@@ -89,9 +89,12 @@ echo
 echo "... displaying HTTP response code"
 echo "http_resp_code=${http_resp_code}"
 echo
-if [ $http_resp_code != 200 ]
-  then
-    echo "something went wrong... endpoint responded with error code [HTTP CODE="$http_resp_code"] (expected was 200)"
-    exit 1
+if [ $http_resp_code != 200 ]; then
+	if [ ${COMMAND} == "DELETE" ] && [ ${http_resp_code} == 404 ]; then
+		echo "... DELETE request responded with 404 - continuing as resource does not exist"
+	else
+		echo "something went wrong... endpoint responded with error code [HTTP CODE="$http_resp_code"] (expected was 200)"
+		exit 1
+	fi
 fi
 echo "provision project/component request (${COMMAND}) completed successfully!"


### PR DESCRIPTION
We might try to delete a project / component which does not exist. In
that case, the operation is actually a no-op so we should continue.

Fixes #781.

Sorry missed that case as I did not start from scratch (with no project existing) ... which is what the AMI does.

I prefer to fail on error in the Go tests to have less false positives.