### PR TITLE
Pass component to delete

### DIFF
--- a/tests/utils/provisioning.go
+++ b/tests/utils/provisioning.go
@@ -72,7 +72,7 @@ func (api *ProvisionAPI) DeleteComponent() error {
 	stages, stderr, err := RunScriptFromBaseDir(
 		"tests/scripts/provisioning-app-api.sh",
 		[]string{"DELETE_COMPONENT"},
-		[]string{},
+		[]string{"PROVISION_FILE=fixtures/create-component-request.json"},
 	)
 
 	if err != nil {


### PR DESCRIPTION
Fixes #783.

Shame on me :( I'm sure I ran this but unsure now how that could have worked ?!

Tests pass locally now:
```
--- PASS: TestVerifyOdsProjectProvisionThruProvisionApi (425.80s)
```