### PR TITLE
ods-core.env in LF endling mode

### DIFF
--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -58,6 +58,8 @@ Add all files of directory `ods-configuration` to git and commit the result. You
 
 "Preparing" also updates the sample files and checks if any params are present in the sample files but missing from the real file.
 
+WARNING: If you are using windows **Cygwin** or **WSL** remember to change ending line CRLF to LF before commit `ods-core.env`
+
 === Tailor
 
 We use https://github.com/opendevstack/tailor[Tailor] to handle OpenShift templates and keep OpenDevStack resources in sync. Please see its https://github.com/opendevstack/tailor#installation[installation instructions] for your platform. The following lists the version requirements:

--- a/docs/modules/administration/pages/installation.adoc
+++ b/docs/modules/administration/pages/installation.adoc
@@ -58,7 +58,7 @@ Add all files of directory `ods-configuration` to git and commit the result. You
 
 "Preparing" also updates the sample files and checks if any params are present in the sample files but missing from the real file.
 
-WARNING: If you are using windows **Cygwin** or **WSL** remember to change ending line CRLF to LF before commit `ods-core.env`
+WARNING: If you are using windows **Cygwin** or **WSL** remember to change ending line CRLF to LF before commit `ods-core.env`, you can find more information on https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings[configure Git ending line]
 
 === Tailor
 


### PR DESCRIPTION
ods-core.env in CRLLF endling mode causes issues when installation or executing ods-core tests
Some issues found:

* Invalid URL's
* base64 can not decode/undecode
* Invalid passwords
* Invalid users