### PR TITLE
Ignore error when build config does not exist during deletion

### DIFF
--- a/tests/utils/clean-up.go
+++ b/tests/utils/clean-up.go
@@ -41,6 +41,7 @@ func RemoveBuildConfigs(projectName string, buildConfigName string) error {
 		"-n", projectName,
 		"delete",
 		"bc", buildConfigName,
+		"--ignore-not-found", "true",
 	}, dir, []string{})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #788.

I found out why I did not see those test failures (https://github.com/opendevstack/ods-core/commit/b77497bd499f874b767faef268042f8ea5989457#r41813784):

> I ran make test, which had some (expected) failures in the verify target (some Tailor diff). So I only checked if the TestVerifyOdsProjectProvisionThruProvisionApi test worked, which it did. Problem is that the create-projects tests do not get executed if the verify target fails, because that target exits with 1. So it never reaches the ./installation-test.sh script ....

I verified that this PR fixes the particular error in #788, but I still need to address the problem that the tests might not all run - and therefore I have no complete test run locally that verifies everything works yet. Will attempt that later today.