### PR TITLE
Increase quickstarter test timeout to 3 hours

### DIFF
--- a/tests/quickstarter-test.sh
+++ b/tests/quickstarter-test.sh
@@ -31,7 +31,7 @@ CD_USER_PWD_B64=$(${ODS_CORE_DIR}/scripts/get-config-param.sh CD_USER_PWD_B64)
 
 echo "Running tests (${QUICKSTARTER}). Output will take a while to arrive ..."
 
-go test -v -count=1 -timeout 1h -p 1 github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER} | tee test-quickstarter-results.txt 2>&1
+go test -v -count=1 -timeout 3h -p 1 github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER} | tee test-quickstarter-results.txt 2>&1
 exitcode="${PIPESTATUS[0]}"
 if [ -f test-quickstarter-results.txt ]; then
     go-junit-report < test-quickstarter-results.txt > test-quickstarter-report.xml


### PR DESCRIPTION
Fixes #791.

The timeout actually applies per package!

See from `go help testflag`:

```
-timeout d
            If a test binary runs longer than duration d, panic.
            If d is 0, the timeout is disabled.
            The default is 10 minutes (10m).
```

In `go help test`, it is made clear that a "test binary" represents one package.
Therefore, the timeout does not apply to the whole test run, but to each
package. Previously tests were located in separate packages.