### PR TITLE
Set better default for ALLOWED_EXTERNAL_PROJECTS

### DIFF
--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -187,6 +187,9 @@ objects:
       dockerStrategy:
         forcePull: true
         noCache: true
+        buildArgs:
+          - name: allowedExternalProjects
+            value: ${ODS_BITBUCKET_PROJECT}
       type: Docker
     successfulBuildsHistoryLimit: 5
     failedBuildsHistoryLimit: 5

--- a/jenkins/webhook-proxy/Dockerfile
+++ b/jenkins/webhook-proxy/Dockerfile
@@ -3,6 +3,10 @@
 # OpenShift yet, for now the easiest is to build the binary in this image.
 FROM golang:1.12-alpine
 
+# Set default ALLOWED_EXTERNAL_PROJECTS env var
+ARG allowedExternalProjects=opendevstack
+ENV ALLOWED_EXTERNAL_PROJECTS=$allowedExternalProjects
+
 RUN apk add --no-cache ca-certificates && \
     mkdir -p /home/webhook-proxy && \
     chgrp -R 0 /home/webhook-proxy && \


### PR DESCRIPTION
This prevents having to set the env var `ALLOWED_EXTERNAL_PROJECTS` on existing webhook proxy instances when users update from 2.x to 3.x, and admins changed the default Bitbucket project from `opendevstack` to something else.

FYI @segator @felipecruz91 

I'll backport to 3.x once approved/merged.