### PR TITLE
Add volumeMode field to PVC resources

### DIFF
--- a/jenkins/ocp-config/deploy/Tailorfile
+++ b/jenkins/ocp-config/deploy/Tailorfile
@@ -4,5 +4,7 @@ ignore-unknown-parameters true
 
 selector template=ods-jenkins-template
 
+preserve pvc:/spec/volumeMode
+
 svc,route,secret,pvc,dc,rolebinding,serviceaccount
 

--- a/jenkins/ocp-config/deploy/jenkins-master.yml
+++ b/jenkins/ocp-config/deploy/jenkins-master.yml
@@ -126,6 +126,7 @@ objects:
       requests:
         storage: '${JENKINS_VOLUME_CAPACITY}'
     storageClassName: '${STORAGE_CLASS_DATA}'
+    volumeMode: Filesystem
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:

--- a/nexus/ocp-config/Tailorfile
+++ b/nexus/ocp-config/Tailorfile
@@ -3,5 +3,6 @@ selector app=nexus
 param-file ../../../ods-configuration/ods-core.env
 ignore-unknown-parameters true
 preserve-immutable-fields true
+preserve pvc:/spec/volumeMode
 
 dc,is,pvc,route,svc

--- a/nexus/ocp-config/pvc.yml
+++ b/nexus/ocp-config/pvc.yml
@@ -34,6 +34,7 @@ objects:
     resources:
       requests:
         storage: ${NEXUS_DATA_CAPACITY}
+    volumeMode: Filesystem
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -51,3 +52,4 @@ objects:
     resources:
       requests:
         storage: ${NEXUS_BACKUP_CAPACITY}
+    volumeMode: Filesystem

--- a/ods-provisioning-app/ocp-config/Tailorfile
+++ b/ods-provisioning-app/ocp-config/Tailorfile
@@ -2,6 +2,7 @@ namespace ods
 selector app=ods-provisioning-app
 param-file ../../../ods-configuration/ods-core.env
 preserve cm:quickstarters.properties:/data
+preserve pvc:/spec/volumeMode
 preserve-immutable-fields true
 ignore-unknown-parameters true
 

--- a/ods-provisioning-app/ocp-config/pvc.yml
+++ b/ods-provisioning-app/ocp-config/pvc.yml
@@ -18,6 +18,7 @@ objects:
     resources:
       requests:
         storage: 20Mi
+    volumeMode: Filesystem
 parameters:
 - name: STORAGE_PROVISIONER
   description: storage class provisioner. For AWS this could be kubernetes.io/aws-ebs. Leave empty for local (e.g. vagrant) deployments

--- a/sonarqube/ocp-config/Tailorfile
+++ b/sonarqube/ocp-config/Tailorfile
@@ -3,5 +3,6 @@ selector app=sonarqube
 param-file ../../../ods-configuration/ods-core.env
 ignore-unknown-parameters true
 preserve-immutable-fields true
+preserve pvc:/spec/volumeMode
 
 bc,dc,is,pvc,route,svc,secret,configmap

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -388,6 +388,7 @@ objects:
       requests:
         storage: 2Gi
     storageClassName: ${STORAGE_CLASS_DATA}
+    volumeMode: Filesystem
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -405,6 +406,7 @@ objects:
       requests:
         storage: 2Gi
     storageClassName: ${STORAGE_CLASS_DATA}
+    volumeMode: Filesystem
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -422,6 +424,7 @@ objects:
       requests:
         storage: 1Gi
     storageClassName: ${STORAGE_CLASS_DATA}
+    volumeMode: Filesystem
 - apiVersion: v1
   kind: Route
   metadata:


### PR DESCRIPTION
This field has been added in Kubernetes 1.18, see
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode.

OpenShift 3.11 uses an older Kubernetes version, which ignores the field
if specified.

OpenShift 4 uses Kubernetes 1.18 and therefore defaults the field to
"Filesystem" if not specified, resulting in Tailor to see drift between
desired and current state if the template does not contain the field.

To allow the same template to be used against both OpenShift 3.11 and 4, we
now specify the field in the template, but preserve the live value.