### PR TITLE
Allow tests to run without gcc

### DIFF
--- a/tests/installation-test.sh
+++ b/tests/installation-test.sh
@@ -2,6 +2,7 @@
 # set -x
 set +e
 set -o pipefail
+export CGO_ENABLED=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}

--- a/tests/quickstarter-test.sh
+++ b/tests/quickstarter-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 set -o pipefail
+export CGO_ENABLED=0
 
 # By default we run all quickstarter tests, otherwise just the quickstarter
 # passed as the first argument to this script.

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -2,6 +2,7 @@
 # set -x
 set +e
 set -o pipefail
+export CGO_ENABLED=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}


### PR DESCRIPTION
CGO is not needed, so we should disable to reduce the dependencies
needed to run the tests.