### PR TITLE
Use new build API version in webhook proxy

### DIFF
--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -24,6 +24,7 @@ const (
 	namespaceFile                  = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 	tokenFile                      = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	caCert                         = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	buildAPIBasePath               = "/apis/build.openshift.io/v1"
 	pipelineConfigFilename         = "pipeline.json.tmpl"
 	repoBaseEnvVar                 = "REPO_BASE"
 	triggerSecretEnvVar            = "TRIGGER_SECRET"
@@ -751,8 +752,9 @@ func newClient(openShiftAPIHost string, triggerSecret string) (*ocClient, error)
 	}
 
 	baseURL := fmt.Sprintf(
-		"https://%s/oapi/v1",
+		"https://%s%s",
 		openShiftAPIHost,
+		buildAPIBasePath,
 	)
 
 	return &ocClient{

--- a/jenkins/webhook-proxy/main_test.go
+++ b/jenkins/webhook-proxy/main_test.go
@@ -612,7 +612,7 @@ func TestForward(t *testing.T) {
 			if string(actualForwardPayload) != string(expectedPayload) {
 				t.Fatalf("Got payload: %s, want: %s", actualForwardPayload, expectedPayload)
 			}
-			if string(actualOpenshiftStatusCode) != string(tc.expectedReturnedStatusCode) {
+			if actualOpenshiftStatusCode != tc.expectedReturnedStatusCode {
 				t.Fatalf("Got HTTP code: %d, want: %d", actualOpenshiftStatusCode, tc.expectedReturnedStatusCode)
 			}
 			if len(expectedOpenshiftResponse) > 0 {

--- a/jenkins/webhook-proxy/pipeline.json.tmpl
+++ b/jenkins/webhook-proxy/pipeline.json.tmpl
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "{{.Name}}",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/fixtures/build-pipeline-branch.json
+++ b/jenkins/webhook-proxy/testdata/fixtures/build-pipeline-branch.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "repository-foo",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/fixtures/build-pipeline-jenkinsfilepath.json
+++ b/jenkins/webhook-proxy/testdata/fixtures/build-pipeline-jenkinsfilepath.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "repository-foo",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/build-component-pipeline.json
+++ b/jenkins/webhook-proxy/testdata/golden/build-component-pipeline.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "baz-foo",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/build-pipeline-branch.json
+++ b/jenkins/webhook-proxy/testdata/golden/build-pipeline-branch.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "repository-foo",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/build-pipeline-jenkinsfilepath.json
+++ b/jenkins/webhook-proxy/testdata/golden/build-pipeline-jenkinsfilepath.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "repository-foo",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/build-pipeline.json
+++ b/jenkins/webhook-proxy/testdata/golden/build-pipeline.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "repository-foo",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/foo-cd-pipeline.json
+++ b/jenkins/webhook-proxy/testdata/golden/foo-cd-pipeline.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "ods-provisioning-app-production",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/pipeline.json
+++ b/jenkins/webhook-proxy/testdata/golden/pipeline.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "repository-master",
         "creationTimestamp": null,

--- a/jenkins/webhook-proxy/testdata/golden/prov-app-pipeline.json
+++ b/jenkins/webhook-proxy/testdata/golden/prov-app-pipeline.json
@@ -1,6 +1,6 @@
 {
     "kind": "BuildConfig",
-    "apiVersion": "v1",
+    "apiVersion": "build.openshift.io/v1",
     "metadata": {
         "name": "ods-provisioning-app-production",
         "creationTimestamp": null,


### PR DESCRIPTION
The new build API version is compatible with OpenShift 4. It also works
on an OpenShift 3.11 cluster, so using the new path / version we can
support both OpenShift versions.