### PR TITLE
Make /home/jenkins/.sonar writable

### DIFF
--- a/jenkins/agent-base/Dockerfile
+++ b/jenkins/agent-base/Dockerfile
@@ -89,6 +89,7 @@ RUN yum install -y \
 
 # Fix permissions.
 RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config \
-    && mkdir -p /home/jenkins/.cache && chmod g+w /home/jenkins/.cache
+    && mkdir -p /home/jenkins/.cache && chmod g+w /home/jenkins/.cache \
+    && mkdir -p /home/jenkins/.sonar && chmod g+w /home/jenkins/.sonar
 
 RUN chmod g+w $JAVA_HOME/lib/security/cacerts


### PR DESCRIPTION
`/home/jenkins/.sonar` is the default user cache directory: `INFO: User cache: /home/jenkins/.sonar/cache`

If the directory does not exist, the scan fails under OpenShift 4 / UBI 8 ...

```
INFO: User cache: /home/jenkins/.sonar/cache
INFO: ------------------------------------------------------------------------
INFO: EXECUTION FAILURE
INFO: ------------------------------------------------------------------------
INFO: Total time: 1:01.306s
INFO: Final Memory: 4M/31M
INFO: ------------------------------------------------------------------------
ERROR: Error during SonarQube Scanner execution
ERROR: Unable to execute SonarQube
ERROR: Caused by: Fail to download sonar-scanner-engine-shaded-8.2.0.32929-all.jar to /home/jenkins/.sonar/cache/_tmp/fileCache1059533374451795878.tmp
ERROR: Caused by: timeout
ERROR: Caused by: Socket closed
```