### PR TITLE
Downgrade supported Nexus version to 3.27, align tested version

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -44,8 +44,8 @@ ODS_BITBUCKET_PROJECT=opendevstack
 
 # Nexus base image
 # See https://hub.docker.com/r/sonatype/nexus3/tags.
-# Note that only 3.28.1 is supported officially.
-NEXUS_FROM_IMAGE=sonatype/nexus3:3.28.1
+# Note that only 3.27.0 is supported officially.
+NEXUS_FROM_IMAGE=sonatype/nexus3:3.27.0
 
 # Nexus host without protocol.
 # The domain should be equal to OPENSHIFT_APPS_BASEDOMAIN (see below).

--- a/nexus/test.sh
+++ b/nexus/test.sh
@@ -6,18 +6,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}
 ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
-NEXUS_VERSION="3.22.0"
+NEXUS_IMAGE=$("${ODS_CORE_DIR}"/scripts/get-sample-param.sh NEXUS_FROM_IMAGE)
 
 function usage {
     printf "Test Nexus setup.\n\n"
-    printf "\t-h|--help\t\tPrint usage\n"
-    printf "\t-v|--verbose\t\tEnable verbose mode\n"
-    printf "\t--verify\t\tSkips setup of local docker container and instead checks existing nexus setup based on ods-core.env\n"
-    printf "\t-n|--no-prompts\t\tDo not prompt for passwords which were not passed in.\n"
+    printf "\t-h|--help\t\t\tPrint usage\n"
+    printf "\t-v|--verbose\t\t\tEnable verbose mode\n"
+    printf "\t--verify\t\t\tSkips setup of local docker container and instead checks existing nexus setup based on ods-core.env\n"
+    printf "\t-n|--no-prompts\t\t\tDo not prompt for passwords which were not passed in.\n"
     printf "\t-a|--admin-password\t\tUse given admin password.\n"
     printf "\t-d|--developer-password\t\tUse given developer password.\n"
-    printf "\t-s|--nexus-version\t\tNexus version, e.g. '3.22.0' (defaults to %s)\n" "${NEXUS_VERSION}"
-    printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
+    printf "\t-s|--nexus-image\t\tNexus image (defaults to: %s)\n" "${NEXUS_IMAGE}"
+    printf "\t-i|--insecure\t\t\tAllow insecure server connections when using SSL\n"
 }
 
 VERIFY_ONLY=false
@@ -45,14 +45,13 @@ while [[ "$#" -gt 0 ]]; do
     -d|--developer-password) DEVELOPER_PASSWORD="$2"; shift;;
     -d=*|--developer-password=*) DEVELOPER_PASSWORD="${1#*=}";;
 
-    -s|--nexus-version) NEXUS_VERSION="$2"; shift;;
-    -s=*|--nexus-version=*) NEXUS_VERSION="${1#*=}";;
+    -s|--nexus-image) NEXUS_IMAGE="$2"; shift;;
+    -s=*|--nexus-image=*) NEXUS_IMAGE="${1#*=}";;
 
     *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
 if ! $VERIFY_ONLY; then
-    CONTAINER_IMAGE="sonatype/nexus3:${NEXUS_VERSION}"
     HOST_PORT="8081"
 
     # HTTP_PROXY="someproxy.local"
@@ -62,8 +61,8 @@ if ! $VERIFY_ONLY; then
     # NO_PROXY=".local,.svc,jcenter.bintray.com"
     NO_PROXY=
 
-    echo "Run container using image ${CONTAINER_IMAGE}"
-    containerId=$(docker run -d -p "${HOST_PORT}:8081" -e HTTP_PROXY="${HTTP_PROXY}" -e HTTPS_PROXY="${HTTPS_PROXY}" -e NO_PROXY="${NO_PROXY}" "${CONTAINER_IMAGE}")
+    echo "Run container using image ${NEXUS_IMAGE}"
+    containerId=$(docker run -d -p "${HOST_PORT}:8081" -e HTTP_PROXY="${HTTP_PROXY}" -e HTTPS_PROXY="${HTTPS_PROXY}" -e NO_PROXY="${NO_PROXY}" "${NEXUS_IMAGE}")
 
     function cleanup {
         echo "Cleanup"

--- a/nexus/test.sh
+++ b/nexus/test.sh
@@ -76,8 +76,8 @@ if ! $VERIFY_ONLY; then
     NEXUS_USERNAME="developer"
     NEXUS_PASSWORD=${DEVELOPER_PASSWORD:-"geHeim"}
 
-    echo "Run ./configure.sh"
-    ./configure.sh \
+    echo "Run configure.sh"
+    "${SCRIPT_DIR}"/configure.sh \
         --admin-password="${NEXUS_ADMIN_PASSWORD}" \
         --developer-password="${NEXUS_PASSWORD}" \
         --nexus="${NEXUS_URL}" \

--- a/scripts/get-sample-param.sh
+++ b/scripts/get-sample-param.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Start build of given image and follows the output.
+# After build finishes, we verify status is "Complete".
+
+set -ue
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_CORE_DIR=${SCRIPT_DIR%/*}
+ODS_CONFIGURATION_SAMPLE_DIR="${ODS_CORE_DIR}/configuration-sample"
+
+if [ ! -f "${ODS_CONFIGURATION_SAMPLE_DIR}/ods-core.env.sample" ]; then
+    echo "Configuration could not be located at ${ODS_CONFIGURATION_SAMPLE_DIR}/ods-core.env.sample."
+    exit 1
+fi
+
+PARAM_NAME=${1:-""}
+
+if [ -z "${PARAM_NAME}" ]; then
+    echo "No param name given. Usage: $0 <PARAM-NAME>"
+    exit 1
+fi
+
+if ! grep "${PARAM_NAME}=" "${ODS_CONFIGURATION_SAMPLE_DIR}/ods-core.env.sample" > /dev/null; then
+    echo "No param ${PARAM_NAME} found." 
+    exit 1
+fi
+
+grep "${PARAM_NAME}=" "${ODS_CONFIGURATION_SAMPLE_DIR}/ods-core.env.sample" | cut -d "=" -f 2-


### PR DESCRIPTION
Default to the Nexus image as defined in the sample config to avoid
drift between the configured and the tested version.

Further, 3.28.0 introduced https://issues.sonatype.org/browse/NEXUS-25162, which broke our configuration script. This change sets the officially supported version to 3.27.0.

Fixes #871.