### PR TITLE
Update to Nexus 3.28

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -44,8 +44,9 @@ ODS_BITBUCKET_PROJECT=opendevstack
 
 # Nexus base image
 # See https://hub.docker.com/r/sonatype/nexus3/tags.
-# Note that only 3.27.0 is supported officially.
-NEXUS_FROM_IMAGE=sonatype/nexus3:3.27.0
+# Note that only 3.28 is supported officially. 3.27 is not supported because
+# 3.28 breaks compatibility, see https://issues.sonatype.org/browse/NEXUS-25162.
+NEXUS_FROM_IMAGE=sonatype/nexus3:3.28.1
 
 # Nexus host without protocol.
 # The domain should be equal to OPENSHIFT_APPS_BASEDOMAIN (see below).

--- a/nexus/json/createRepos.json
+++ b/nexus/json/createRepos.json
@@ -1,7 +1,7 @@
 {
   "name":"createRepos",
   "content":"import org.sonatype.nexus.blobstore.api.BlobStoreManager;
-  import org.sonatype.nexus.repository.storage.WritePolicy;
+  import org.sonatype.nexus.repository.config.WritePolicy;
   import org.sonatype.nexus.repository.maven.VersionPolicy;
   import org.sonatype.nexus.repository.maven.LayoutPolicy;
   repository.createMavenHosted('candidates', 'candidates', true, VersionPolicy.RELEASE, WritePolicy.ALLOW_ONCE, LayoutPolicy.STRICT);


### PR DESCRIPTION
Breaks support for 3.27 because of
https://issues.sonatype.org/browse/NEXUS-25162.

Since the script can only be used on new installations right now,
requiring the very latest version is OK in my opinion.

Closes #873.