### PR TITLE
Allow to customize sharedLibraryRef and agentImageTag in tests

### DIFF
--- a/tests/quickstarter/quickstarter_test.go
+++ b/tests/quickstarter/quickstarter_test.go
@@ -129,6 +129,14 @@ func TestQuickstarter(t *testing.T) {
 					if len(step.ProvisionParams.Branch) > 0 {
 						branch = renderTemplate(t, step.ProvisionParams.Branch, tmplData)
 					}
+					agentImageTag := config["ODS_IMAGE_TAG"]
+					if len(step.ProvisionParams.AgentImageTag) > 0 {
+						agentImageTag = renderTemplate(t, step.ProvisionParams.AgentImageTag, tmplData)
+					}
+					sharedLibraryRef := agentImageTag
+					if len(step.ProvisionParams.SharedLibraryRef) > 0 {
+						sharedLibraryRef = renderTemplate(t, step.ProvisionParams.SharedLibraryRef, tmplData)
+					}
 					request = utils.RequestBuild{
 						Repository: "ods-quickstarters",
 						Branch:     branch,
@@ -145,6 +153,14 @@ func TestQuickstarter(t *testing.T) {
 							{
 								Name:  "ODS_IMAGE_TAG",
 								Value: config["ODS_IMAGE_TAG"],
+							},
+							{
+								Name:  "AGENT_IMAGE_TAG",
+								Value: agentImageTag,
+							},
+							{
+								Name:  "SHARED_LIBRARY_REF",
+								Value: sharedLibraryRef,
 							},
 							{
 								Name:  "PROJECT_ID",

--- a/tests/quickstarter/steps.go
+++ b/tests/quickstarter/steps.go
@@ -48,10 +48,16 @@ type TestStepProvisionParams struct {
 	// Pipeline allows to customize the pipeline name.
 	// If empty, the pipeline name is generated.
 	Pipeline string `json:"pipeline"`
-	// Branch for which to run the pipeline.
+	// Quickstarter branch for which to run the pipeline.
 	// For "provision" steps, it defaults to ODS_GIT_REF.
 	// For "build" steps, it defaults to "master".
 	Branch string `json:"branch"`
+	// Jenkins Agent image tag.
+	// Defaults to ODS_IMAGE_TAG.
+	AgentImageTag string `json:"agentImageTag"`
+	// Jenkins Shared library Git reference.
+	// Defaults to AgentImageTag.
+	SharedLibraryRef string `json:"sharedLibraryRef"`
 	// Verify parameters.
 	Verify *TestStepVerify `json:"verify"`
 }


### PR DESCRIPTION
That way, one can run tests against e.g. a feature branch of the shared
library, or against an experimental agent image.