### PR TITLE
Remove empty BuildConfig triggers

### DIFF
--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -112,7 +112,6 @@ objects:
           kind: DockerImage
           name: ${JENKINS_MASTER_BASE_FROM_IMAGE}
     successfulBuildsHistoryLimit: 5
-    triggers: []
 - kind: BuildConfig
   apiVersion: v1
   metadata:
@@ -158,7 +157,6 @@ objects:
         dockerfilePath: ${JENKINS_AGENT_DOCKERFILE_PATH}
       type: Docker
     successfulBuildsHistoryLimit: 5
-    triggers: []
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -198,4 +196,3 @@ objects:
     successfulBuildsHistoryLimit: 5
     failedBuildsHistoryLimit: 5
     nodeSelector: null
-    triggers: []

--- a/nexus/ocp-config/bc.yml
+++ b/nexus/ocp-config/bc.yml
@@ -59,4 +59,3 @@ objects:
           name: ${NEXUS_FROM_IMAGE}
       type: Docker
     successfulBuildsHistoryLimit: 5
-    triggers: []

--- a/ods-document-generation-svc/ocp-config/bc.yml
+++ b/ods-document-generation-svc/ocp-config/bc.yml
@@ -69,4 +69,3 @@ objects:
           kind: DockerImage
           name: ${DOC_GEN_FROM_IMAGE}
     successfulBuildsHistoryLimit: 5
-    triggers: []

--- a/ods-provisioning-app/ocp-config/bc.yml
+++ b/ods-provisioning-app/ocp-config/bc.yml
@@ -61,4 +61,3 @@ objects:
           kind: DockerImage
           name: ${PROV_APP_FROM_IMAGE}
     successfulBuildsHistoryLimit: 5
-    triggers: []

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -142,7 +142,6 @@ objects:
             value: ${APP_DNS}
       type: Docker
     successfulBuildsHistoryLimit: 5
-    triggers: []
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:


### PR DESCRIPTION
In OpenShift 3.11, they are automatically added to live configuration if
not specified in the template. Tailor ignores empty triggers during
diffing.

In OpenShift 4, empty triggers are removed in live configuration. During
diffing, Tailor detects drift as empty triggers are defined in the
template.

The easy solution here is to remove the empty BuildConfig triggers from
the templates.