### PR TITLE
Install Helm

### DIFF
--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -5,6 +5,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     CNES_REPORT_VERSION=3.2.2 \
     TAILOR_VERSION=1.2.2 \
+    HELM_VERSION=3.4.1 \
+    HELM_PLUGIN_DIFF_VERSION=3.1.3 \
+    HELM_PLUGIN_SECRETS_VERSION=3.3.0 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
     OSTREE_VERSION=2018.5-1
@@ -44,10 +47,22 @@ RUN cd /tmp \
 
 # Install Tailor.
 RUN cd /tmp \
-	&& curl -LOv https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
-	&& mv tailor-linux-amd64 /usr/local/bin/tailor \
-	&& chmod a+x /usr/local/bin/tailor \
-	&& tailor version
+    && curl -LOv https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
+    && mv tailor-linux-amd64 /usr/local/bin/tailor \
+    && chmod a+x /usr/local/bin/tailor \
+    && tailor version
+
+# Install Helm.
+RUN cd /tmp \
+    && mkdir -p /tmp/helm \
+    && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz -C /tmp/helm \
+    && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
+    && chmod a+x /usr/local/bin/helm \
+    && helm version \
+    && helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
+    && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
+    && rm -rf /tmp/helm
 
 # Install GIT-LFS extension https://git-lfs.github.com/.
 RUN cd /tmp \

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -5,6 +5,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     CNES_REPORT_VERSION=3.2.2 \
     TAILOR_VERSION=1.3.0 \
+    HELM_VERSION=3.4.1 \
+    HELM_PLUGIN_DIFF_VERSION=3.1.3 \
+    HELM_PLUGIN_SECRETS_VERSION=3.3.0 \
     GIT_LFS_VERSION=2.6.1 \
     JAVA_HOME=/usr/lib/jvm/jre
 
@@ -39,10 +42,22 @@ RUN cd /tmp \
 
 # Install Tailor.
 RUN cd /tmp \
-	&& curl -LO https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
-	&& mv tailor-linux-amd64 /usr/local/bin/tailor \
-	&& chmod a+x /usr/local/bin/tailor \
-	&& tailor version
+    && curl -LO https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
+    && mv tailor-linux-amd64 /usr/local/bin/tailor \
+    && chmod a+x /usr/local/bin/tailor \
+    && tailor version
+
+# Install Helm.
+RUN cd /tmp \
+    && mkdir -p /tmp/helm \
+    && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+    && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz -C /tmp/helm \
+    && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
+    && chmod a+x /usr/local/bin/helm \
+    && helm version \
+    && helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
+    && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
+    && rm -rf /tmp/helm
 
 # Install GIT-LFS extension https://git-lfs.github.com/.
 RUN cd /tmp \


### PR DESCRIPTION
Also installs two helpful plugins, helm-diff and helm-secrets. Other plugins might be added depending on user need.

Closes #551.

This also installs `helm` into the RHEL7 image, even though there is no full support for OpenShift 3.11. That said, it might still be helpful for some use cases (e.g. deploying elsewhere), and it keeps the two images in sync. I'm not planning to backport this change to 3.x.

How OpenDevStack will make use of Helm directly has not been decided yet, but it is likely to be integrated, see https://github.com/opendevstack/ods-jenkins-shared-library/issues/495.

FYI @serverhorror @segfault16