### PR TITLE
Enable repos on demand

### DIFF
--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -14,7 +14,11 @@ ARG SNYK_DISTRIBUTION_URL
 # Add CentOS 8 repositories.
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 
-RUN yum -y install glibc-langpack-en openssl \
+RUN yum -y --enablerepo centos-baseos install glibc-langpack-en \
+    && yum clean all \
+    && rm -rf /var/cache/yum/*
+
+RUN yum -y install openssl \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
@@ -74,7 +78,7 @@ RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.
-RUN yum install -y skopeo \
+RUN yum install -y --enablerepo centos-appstream skopeo \
     && yum clean all \
     && rm -rf /var/cache/yum/* \
     && skopeo --version

--- a/jenkins/agent-base/yum.repos.d/centos8.repo
+++ b/jenkins/agent-base/yum.repos.d/centos8.repo
@@ -1,13 +1,13 @@
 [centos-baseos]
 name=CentOS-8-BaseOS
 baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
 baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official


### PR DESCRIPTION
In order to get as many packages as possible through the UBI repos, this disables the extra repos by default.

Related to https://github.com/opendevstack/ods-quickstarters/pull/501.