### PR TITLE
Revert "Enable repos on demand"

### DIFF
--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -17,11 +17,7 @@ ARG SNYK_DISTRIBUTION_URL
 # Add CentOS 8 repositories.
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
 
-RUN yum -y --enablerepo centos-baseos install glibc-langpack-en \
-    && yum clean all \
-    && rm -rf /var/cache/yum/*
-
-RUN yum -y install openssl \
+RUN yum -y install glibc-langpack-en openssl \
     && yum clean all \
     && rm -rf /var/cache/yum/*
 
@@ -93,7 +89,7 @@ RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.
-RUN yum install -y --enablerepo centos-appstream skopeo \
+RUN yum install -y skopeo \
     && yum clean all \
     && rm -rf /var/cache/yum/* \
     && skopeo --version

--- a/jenkins/agent-base/yum.repos.d/centos8.repo
+++ b/jenkins/agent-base/yum.repos.d/centos8.repo
@@ -1,13 +1,13 @@
 [centos-baseos]
 name=CentOS-8-BaseOS
 baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os/
-enabled=0
+enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [centos-appstream]
 name=CentOS-8-AppStream
 baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
-enabled=0
+enabled=1
 gpgcheck=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official


### PR DESCRIPTION
Reverts opendevstack/ods-core#906. This breaks the GitHub Actions builds, see https://github.com/opendevstack/ods-quickstarters/runs/1474316293.

We really need to understand why the quay.io images cannot find the UBI repos.