### PR TITLE
parameterize prov app openshift service configuration

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -239,6 +239,9 @@ DOCKER_REGISTRY=docker-registry.default.svc:5000
 # Example: hostA;hostB:8443;hostC:8443
 APP_DNS=192.168.56.101.nip.io
 
+# URI of the OpenShift API
+OPENSHIFT_API_URL=https://192.168.56.101:8443
+
 # Host DNS of the OpenShift console to create the right links
 OPENSHIFT_CONSOLE_HOST=https://192.168.56.101:8443
 
@@ -337,6 +340,9 @@ JIRA_PROJECT_TEMPLATE_KEY_NAMES=${project.template.default.key},kanban
 # List of default groups to be permissioned in openshift on project creation (value is optional and can be empty).
 # e.g: DEFAULT_OPENSHIFT_PERMISSION_GROUPS="ADMINGROUP=MY-DEFAULT-CLUSTER-ADMIN-GROUP"
 DEFAULT_OPENSHIFT_PERMISSION_GROUPS=
+
+# Enable or disable the openshift service in the provisioning app (values: "true" or "false")
+PROV_APP_OPENSHIFT_SERVICE_ENABLED=true
 
 # List of additional jira project template configuration
 # Note: multiline parameters replace is supported... if you need to add multiple lines add as separator "\n".

--- a/ods-devenv/scripts/deploy.sh
+++ b/ods-devenv/scripts/deploy.sh
@@ -1489,6 +1489,8 @@ function create_configuration() {
     sed -i "s|PROV_APP_CONFLUENCE_ADAPTER_ENABLED=.*$|PROV_APP_CONFLUENCE_ADAPTER_ENABLED=false|" ods-core.env
     sed -i "s|PROV_APP_AUTH_BASIC_AUTH_ENABLED=.*$|PROV_APP_AUTH_BASIC_AUTH_ENABLED=true|" ods-core.env
     sed -i "s|PROV_APP_PROVISION_CLEANUP_INCOMPLETE_PROJECTS_ENABLED=.*$|PROV_APP_PROVISION_CLEANUP_INCOMPLETE_PROJECTS_ENABLED=true|" ods-core.env
+    sed -i "s|PROV_APP_OPENSHIFT_SERVICE_ENABLED=.*$|PROV_APP_OPENSHIFT_SERVICE_ENABLED=true|" ods-core.env
+    sed -i "s|OPENSHIFT_API_URL=.*$|OPENSHIFT_API_URL=https://api.odsbox.lan:8443|" ods-core.env
 
     # OpenShift
     sed -i "s|OPENSHIFT_CONSOLE_HOST=.*$|OPENSHIFT_CONSOLE_HOST=https://ocp.${odsbox_domain}:8443|" ods-core.env

--- a/ods-provisioning-app/ocp-config/cm.yml
+++ b/ods-provisioning-app/ocp-config/cm.yml
@@ -21,6 +21,9 @@ parameters:
 - name: CROWD_URL
   required: true
   description: the URI of crowd used to authenticate users from the app against
+- name: OPENSHIFT_API_URL
+  required: true
+  description: the URI of the OCP api
 - name: OPENSHIFT_CONSOLE_HOST
   required: true
   description: the console host of the OCP cluster
@@ -71,6 +74,9 @@ parameters:
 - name: READABLE_OPENDEVSTACK_REPOS
   required: true
   description: Repositories which the project specific technical user can read
+- name: PROV_APP_OPENSHIFT_SERVICE_ENABLED
+  required: true
+  description: Enable or disable the openshift service in the provisioning app
 - name: DEFAULT_OPENSHIFT_PERMISSION_GROUPS
   required: false
   description: List of default groups to be permissioned in openshift on project creation (value is optional and can be empty)
@@ -191,6 +197,10 @@ objects:
 
       # List of default groups to be permissioned in openshift on project creation (value can be empty)
       jenkinspipeline.create-project.default-project-groups=${DEFAULT_OPENSHIFT_PERMISSION_GROUPS}
+
+      # openshift service
+      services.openshift.enabled=${PROV_APP_OPENSHIFT_SERVICE_ENABLED}
+      openshift.api.uri=${OPENSHIFT_API_URL}
 
       # openshift properties
       openshift.apps.basedomain=${OPENSHIFT_APPS_BASEDOMAIN}


### PR DESCRIPTION
fixes https://github.com/opendevstack/ods-provisioning-app/issues/646
I have successfully tested the AMI build stage TestVerifyOdsProjectProvisionThruProvisionApi with this fix.
It adds the missing parameterization so that the AMI build does not fail due to missing OCP API URL.

