### PR TITLE
Normalize LF for ods-core.env files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Tells Git to (1) normalize line endings to LF on checkin and 
-# (2) prevent conversion to CRLF when the file is checked out.
-configuration-sample/ods-core.env text eol=lf
-configuration-sample/ods-core.env.sample text eol=lf
+# This attribute enables and controls end-of-line normalization.
+# When a text file is normalized, its line endings are converted to LF in the repository.
+configuration-sample/ods-core.env text
+configuration-sample/ods-core.env.sample text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Tells Git to (1) normalize line endings to LF on checkin and 
+# (2) prevent conversion to CRLF when the file is checked out.
+configuration-sample/ods-core.env text eol=lf
+configuration-sample/ods-core.env.sample text eol=lf


### PR DESCRIPTION
I'd like to propose the following non-urgent enhancement to mitigate a human error-prone aspect from the current ODS installation guide.

While installing ODS 3.1, I made the mistake of pushing the `ods-core.env` file to Bitbucket with `CRLF` line endings. Although the documentation clearly states this issue with the following warning message, I missed it.

> If you are using windows Cygwin or WSL remember to change ending line CRLF to LF before commit ods-core.env, you can find more information on configure Git ending line

I think we can programmatically avoid this to happen to anyone by checking a `.gitattributes` file in the repository.  We can then tell Git to (1) normalize line endings to LF on checkin and (2) prevent conversion to CRLF when the file is checked out.