### PR TITLE
fixes freeze of systemctl enable docker

### DIFF
--- a/ods-devenv/scripts/deploy.sh
+++ b/ods-devenv/scripts/deploy.sh
@@ -401,7 +401,9 @@ function setup_rdp() {
 #######################################
 function install_docker() {
     sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-    sudo yum -y install docker-ce docker-ce-cli containerd.io
+    echo "installing docker-ce packages"
+    sudo yum -y install docker-ce-3:19.03.14-3.el7.x86_64
+    echo "enabling docker in systemctl"
     sudo systemctl enable --now docker
 
     echo "updating docker insecure registries"


### PR DESCRIPTION
Installation of odsbox is failing because the activation of docker in systemctl freezes.

This problem seems to happen since a new version of the docker package is available.

To fix this problem I'm fixing the docker version to install to the latest one that worked.

I tested running packer locally for the branch bugfix/ods-devenv-build-fixes and also master.

