### PR TITLE
Fix installation of SOPS

### DIFF
--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -7,7 +7,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     TAILOR_VERSION=1.2.2 \
     HELM_VERSION=3.4.1 \
     HELM_PLUGIN_DIFF_VERSION=3.1.3 \
-    HELM_PLUGIN_SECRETS_VERSION=3.3.0 \
+    HELM_PLUGIN_SECRETS_VERSION=3.3.5 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
     OSTREE_VERSION=2018.5-1
@@ -62,6 +62,7 @@ RUN cd /tmp \
     && helm version \
     && helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
     && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
+    && sops --version \
     && rm -rf /tmp/helm
 
 # Install GIT-LFS extension https://git-lfs.github.com/.

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -7,7 +7,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     TAILOR_VERSION=1.3.0 \
     HELM_VERSION=3.4.1 \
     HELM_PLUGIN_DIFF_VERSION=3.1.3 \
-    HELM_PLUGIN_SECRETS_VERSION=3.3.0 \
+    HELM_PLUGIN_SECRETS_VERSION=3.3.5 \
     GIT_LFS_VERSION=2.6.1 \
     JAVA_HOME=/usr/lib/jvm/jre
 
@@ -57,6 +57,7 @@ RUN cd /tmp \
     && helm version \
     && helm plugin install https://github.com/databus23/helm-diff --version v${HELM_PLUGIN_DIFF_VERSION} \
     && helm plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_PLUGIN_SECRETS_VERSION} \
+    && sops --version \
     && rm -rf /tmp/helm
 
 # Install GIT-LFS extension https://git-lfs.github.com/.


### PR DESCRIPTION
`helm-secrets` 3.3.0 used an incorrect checksum for `sops`, which led to a failure to install `sops`. See https://github.com/jkroepke/helm-secrets/pull/49.