### PR TITLE
Check for finished build more often

### DIFF
--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -108,10 +108,10 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 	build, err := buildClient.Builds(jenkinsNamespace).Get(buildName, metav1.GetOptions{})
 	count := 0
 	// especially provision builds with CLIs take longer ...
-	max := 180
+	max := 400
 	for (err != nil || build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning) && count < max {
 		build, err = buildClient.Builds(jenkinsNamespace).Get(buildName, metav1.GetOptions{})
-		time.Sleep(45 * time.Second)
+		time.Sleep(20 * time.Second)
 		if err != nil {
 			fmt.Printf("Err Build: %s is still not available, %s\n", buildName, err)
 			// try to refresh the client - sometimes the token does expire...


### PR DESCRIPTION
Currently we have 18 quickstarters, which leads to around 6mins of waiting if tests run sequentially. Reducing the interval should bring this down to around 3mins.

Old timeout was 135mins, new is 133mins ... should still work, I think this is anyway excessively long.