### PR TITLE
Fix PVC creation on OpenShift 4

### DIFF
--- a/nexus/ocp-config/Tailorfile
+++ b/nexus/ocp-config/Tailorfile
@@ -4,5 +4,6 @@ param-file ../../../ods-configuration/ods-core.env
 ignore-unknown-parameters true
 preserve-immutable-fields true
 preserve pvc:/spec/volumeMode
+preserve pvc:/metadata/annotations/volume.beta.kubernetes.io/storage-class
 
 dc,is,pvc,route,svc

--- a/nexus/ocp-config/pvc.yml
+++ b/nexus/ocp-config/pvc.yml
@@ -21,7 +21,6 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS_DATA}
       volume.beta.kubernetes.io/storage-provisioner: ${STORAGE_PROVISIONER}
     finalizers:
     - kubernetes.io/pvc-protection
@@ -34,12 +33,12 @@ objects:
     resources:
       requests:
         storage: ${NEXUS_DATA_CAPACITY}
+    storageClassName: ${STORAGE_CLASS_DATA}
     volumeMode: Filesystem
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS_BACKUP}
       volume.beta.kubernetes.io/storage-provisioner: ${STORAGE_PROVISIONER}
     finalizers:
     - kubernetes.io/pvc-protection
@@ -52,4 +51,5 @@ objects:
     resources:
       requests:
         storage: ${NEXUS_BACKUP_CAPACITY}
+    storageClassName: ${STORAGE_CLASS_BACKUP}
     volumeMode: Filesystem

--- a/ods-provisioning-app/ocp-config/Tailorfile
+++ b/ods-provisioning-app/ocp-config/Tailorfile
@@ -3,6 +3,7 @@ selector app=ods-provisioning-app
 param-file ../../../ods-configuration/ods-core.env
 preserve cm:quickstarters.properties:/data
 preserve pvc:/spec/volumeMode
+preserve pvc:/metadata/annotations/volume.beta.kubernetes.io/storage-class
 preserve-immutable-fields true
 ignore-unknown-parameters true
 

--- a/ods-provisioning-app/ocp-config/is.yml
+++ b/ods-provisioning-app/ocp-config/is.yml
@@ -8,6 +8,5 @@ objects:
       app: ods-provisioning-app
     name: ods-provisioning-app
   spec:
-    dockerImageRepository: ods-provisioning-app
     lookupPolicy:
       local: false

--- a/ods-provisioning-app/ocp-config/pvc.yml
+++ b/ods-provisioning-app/ocp-config/pvc.yml
@@ -5,7 +5,6 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS_DATA}
       volume.beta.kubernetes.io/storage-provisioner: ${STORAGE_PROVISIONER}
     finalizers:
     - kubernetes.io/pvc-protection
@@ -18,6 +17,7 @@ objects:
     resources:
       requests:
         storage: 20Mi
+    storageClassName: ${STORAGE_CLASS_DATA}
     volumeMode: Filesystem
 parameters:
 - name: STORAGE_PROVISIONER


### PR DESCRIPTION
Otherwise the PVC resources are stuck in "pending".

The old way worked on an Azure RedHat Openshift 4.5, but fails on RedHat Dedicated OpenShift 4.6.

Note that the SonarQube PVC resources are already defined with `storageClassName`, and without the annotation.

Will open a PR for `master` as well.