### PR TITLE
add aws quickstarter into the Prov-app Config Map

### DIFF
--- a/ods-provisioning-app/ocp-config/cm.yml
+++ b/ods-provisioning-app/ocp-config/cm.yml
@@ -335,6 +335,10 @@ objects:
       jenkinspipeline.quickstarter.fe-ionic.desc=Mobile - Ionic
       jenkinspipeline.quickstarter.fe-ionic.repo=ods-quickstarters
 
+      # Infra quickstarters
+      jenkinspipeline.quickstarter.inf-terraform-aws.desc=Infra - AWS Terraform
+      jenkinspipeline.quickstarter.inf-terraform-aws.repo=ods-quickstarters
+
       # Other quickstarters
       jenkinspipeline.quickstarter.be-fe-mono-repo-plain.desc=FE/BE MonoRepo
       jenkinspipeline.quickstarter.be-fe-mono-repo-plain.repo=ods-quickstarters


### PR DESCRIPTION
Update the Config Map of the Prov-app with the new AWS Terraform quickstarter

Follow up of https://github.com/opendevstack/ods-quickstarters/pull/565

@michaelsauter @metmajer @clemensutschig @gerardcl

We have made the Pull request in your behalf @nichtraunzer