### PR TITLE
Install Aquasec scannercli on jenkins base image

### DIFF
--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -205,6 +205,15 @@ JENKINS_AGENT_DOCKERFILE_PATH=Dockerfile.rhel7
 # Latest tested version is v1.217.3.
 JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.217.3/snyk-linux
 
+#Aqua CCLI binary distribution url
+# Leave empty to avoid installing Aqua.
+# Releases are published at https://download.aquasec.com/scanner
+# To Download the aqua scanner cli requires a valid account on aquasec.com
+# Latest tested version is 6.0.0
+#JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
+JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=
+
+
 # Repository of shared library
 # You may also point to repository underneath REPO_BASE.
 SHARED_LIBRARY_REPOSITORY=https://github.com/opendevstack/ods-jenkins-shared-library.git

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -205,7 +205,7 @@ JENKINS_AGENT_DOCKERFILE_PATH=Dockerfile.rhel7
 # Latest tested version is v1.217.3.
 JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.217.3/snyk-linux
 
-#Aqua CCLI binary distribution url
+#Aqua CLI binary distribution url
 # Leave empty to avoid installing Aqua.
 # Releases are published at https://download.aquasec.com/scanner
 # To Download the aqua scanner cli requires a valid account on aquasec.com

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -205,13 +205,13 @@ JENKINS_AGENT_DOCKERFILE_PATH=Dockerfile.rhel7
 # Latest tested version is v1.217.3.
 JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.217.3/snyk-linux
 
-# Aqua CLI binary distribution url
-# Leave empty to avoid installing Aqua.
+# AquaSec CLI binary distribution url
+# Leave empty to avoid installing AquaSec.
 # Releases are published at https://download.aquasec.com/scanner
-# To Download the aqua scanner cli requires a valid account on aquasec.com
+# To Download the aquaSec scanner cli requires a valid account on aquasec.com
 # Latest tested version is 6.0.0
 # Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
-JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=
+JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 
 # Repository of shared library

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -205,7 +205,7 @@ JENKINS_AGENT_DOCKERFILE_PATH=Dockerfile.rhel7
 # Latest tested version is v1.217.3.
 JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.217.3/snyk-linux
 
-#Aqua CLI binary distribution url
+# Aqua CLI binary distribution url
 # Leave empty to avoid installing Aqua.
 # Releases are published at https://download.aquasec.com/scanner
 # To Download the aqua scanner cli requires a valid account on aquasec.com

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -210,7 +210,7 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # Releases are published at https://download.aquasec.com/scanner
 # To Download the aqua scanner cli requires a valid account on aquasec.com
 # Latest tested version is 6.0.0
-#JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
 JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=
 
 

--- a/docs/modules/getting-started/pages/index.adoc
+++ b/docs/modules/getting-started/pages/index.adoc
@@ -60,7 +60,7 @@ Planned work (subject to change):
 - OpenShift 4 support (keeping 3.11 compatibility)
 - Support deploying to multiple Q/P clusters in the orchestration pipeline
 - New/Reworked machine learning quickstarter
-- Integration with Aqua Security
+- Integration with AquaSec Security
 - Implement health checks for quickstarters
 - Provisioning App: Support config of multiple identity providers and enable new UI by default
 

--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -11,6 +11,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
+ARG AQUA_SCANNERCLI_URL
 
 RUN yum -y install \
     openssl \
@@ -68,6 +69,16 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
     && echo 'Snyk CLI version:' \
     && snyk --version \
     && echo 'Snyk installation completed!'; \
+    fi
+
+# Optionally install Aquasec.
+RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUA_SCANNERCLI_URL \
+    && curl -Lv $AQUA_SCANNERCLI_URL --output aquasec \
+    && mv aquasec /usr/local/bin \
+    && chmod +rwx /usr/local/bin/aquasec \
+    && echo 'AquaSec CLI version:' \
+    && aquasec --version \
+    && echo 'Aqua installation completed!'; \
     fi
 
 # Set java proxy var.

--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -73,7 +73,7 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
 
 # Optionally install Aquasec.
 RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUA_SCANNERCLI_URL \
-    && curl -Lv $AQUA_SCANNERCLI_URL --output aquasec \
+    && wget $AQUA_SCANNERCLI_URL -O aquasec \
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \

--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -77,7 +77,7 @@ RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' 
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \
-    && aquasec --version \
+    && aquasec version \
     && echo 'Aqua installation completed!'; \
     fi
 

--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -11,7 +11,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
-ARG AQUA_SCANNERCLI_URL
+ARG AQUASEC_SCANNERCLI_URL
 
 RUN yum -y install \
     openssl \
@@ -72,13 +72,13 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
     fi
 
 # Optionally install Aquasec.
-RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUA_SCANNERCLI_URL \
-    && wget $AQUA_SCANNERCLI_URL -O aquasec \
+RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUASEC_SCANNERCLI_URL \
+    && wget $AQUASEC_SCANNERCLI_URL -O aquasec \
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \
     && aquasec version \
-    && echo 'Aqua installation completed!'; \
+    && echo 'AquaSec installation completed!'; \
     fi
 
 # Set java proxy var.

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -10,7 +10,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
-ARG AQUA_SCANNERCLI_URL
+ARG AQUASEC_SCANNERCLI_URL
 
 # Add CentOS 8 repositories.
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
@@ -67,13 +67,13 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
     fi
 
 # Optionally install Aquasec.
-RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUA_SCANNERCLI_URL \
-    && wget $AQUA_SCANNERCLI_URL -O aquasec \
+RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUASEC_SCANNERCLI_URL \
+    && wget $AQUASEC_SCANNERCLI_URL -O aquasec \
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \
     && aquasec version \
-    && echo 'Aqua installation completed!'; \
+    && echo 'AquaSec installation completed!'; \
     fi
 
 

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -10,6 +10,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
+ARG AQUA_SCANNERCLI_URL
 
 # Add CentOS 8 repositories.
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
@@ -64,6 +65,17 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
     && snyk --version \
     && echo 'Snyk installation completed!'; \
     fi
+
+# Optionally install Aquasec.
+RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUA_SCANNERCLI_URL \
+    && curl -Lv $AQUA_SCANNERCLI_URL --output aquasec \
+    && mv aquasec /usr/local/bin \
+    && chmod +rwx /usr/local/bin/aquasec \
+    && echo 'AquaSec CLI version:' \
+    && aquasec --version \
+    && echo 'Aqua installation completed!'; \
+    fi
+
 
 # Set java proxy var.
 COPY set_java_proxy.sh /tmp/set_java_proxy.sh

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -68,7 +68,7 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
 
 # Optionally install Aquasec.
 RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUA_SCANNERCLI_URL \
-    && curl -Lv $AQUA_SCANNERCLI_URL --output aquasec \
+    && wget $AQUA_SCANNERCLI_URL -O aquasec \
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -72,7 +72,7 @@ RUN if [ -z $AQUA_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' 
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \
-    && aquasec --version \
+    && aquasec version \
     && echo 'Aqua installation completed!'; \
     fi
 

--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -34,7 +34,7 @@ parameters:
   description: OpenShift application base dns - used for grabbing the root ca and adding into the agent
 - name: JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL
   description: optional uri that points to the snyk binary distribution (i.e. https://github.com/snyk/snyk/releases/download/v1.180.1/snyk-linux)
-- name: JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL
+- name: JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL
   description: optional uri that points to the aquasec binary distribution (i.e. https://download.aquasec.com/scanner/6.0.0/scannercli)
 - name: SONAR_EDITION
   description: SonarQube edition. One of "community", "developer", "enterprise" or "datacenter".
@@ -133,8 +133,8 @@ objects:
             value: ${APP_DNS}
           - name: SNYK_DISTRIBUTION_URL
             value: ${JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL}
-          - name: AQUA_SCANNERCLI_URL
-            value: ${JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL}
+          - name: AQUASEC_SCANNERCLI_URL
+            value: ${JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL}
         from:
           kind: DockerImage
           name: ${JENKINS_AGENT_BASE_FROM_IMAGE}

--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -179,4 +179,5 @@ objects:
       type: Docker
     successfulBuildsHistoryLimit: 5
     failedBuildsHistoryLimit: 5
-    nodeSelector: null    
+    nodeSelector: null
+    

--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -34,6 +34,8 @@ parameters:
   description: OpenShift application base dns - used for grabbing the root ca and adding into the agent
 - name: JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL
   description: optional uri that points to the snyk binary distribution (i.e. https://github.com/snyk/snyk/releases/download/v1.180.1/snyk-linux)
+- name: JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL
+  description: optional uri that points to the aquasec binary distribution (i.e. https://download.aquasec.com/scanner/6.0.0/scannercli)
 - name: SONAR_EDITION
   description: SonarQube edition. One of "community", "developer", "enterprise" or "datacenter".
 - name: SONAR_VERSION
@@ -131,6 +133,8 @@ objects:
             value: ${APP_DNS}
           - name: SNYK_DISTRIBUTION_URL
             value: ${JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL}
+          - name: AQUA_SCANNERCLI_URL
+            value: ${JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL}
         from:
           kind: DockerImage
           name: ${JENKINS_AGENT_BASE_FROM_IMAGE}

--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -180,3 +180,4 @@ objects:
     successfulBuildsHistoryLimit: 5
     failedBuildsHistoryLimit: 5
     nodeSelector: null
+    

--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -179,5 +179,4 @@ objects:
       type: Docker
     successfulBuildsHistoryLimit: 5
     failedBuildsHistoryLimit: 5
-    nodeSelector: null
-    
+    nodeSelector: null    


### PR DESCRIPTION
Aquasec is installed on base image if ```JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL```  it's defined on ods-configuration

Example URL
```
#JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
```