### PR TITLE
add aws quickstarter into the Prov-app Config Map for master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add PHP plugin to Sonarqube ([#536](https://github.com/opendevstack/ods-core/issues/536))
 - add doc gen service and new selectors ([#515](https://github.com/opendevstack/ods-core/pull/515))
 - Add SonarQube readiness probe ([#495](https://github.com/opendevstack/ods-core/pull/495))
+- Add AWS quickstarter into the Prov-app config map ([#970](https://github.com/opendevstack/ods-core/pull/970))
 
 ### Changed
 - Updated start-and-follow-build script to wait for OpenShift build to complete sucessfully ([#939](https://github.com/opendevstack/ods-core/pull/939))

--- a/ods-provisioning-app/ocp-config/cm.yml
+++ b/ods-provisioning-app/ocp-config/cm.yml
@@ -343,6 +343,10 @@ objects:
       jenkinspipeline.quickstarter.fe-ionic.desc=Mobile - Ionic
       jenkinspipeline.quickstarter.fe-ionic.repo=ods-quickstarters
 
+      # Infra quickstarters
+      jenkinspipeline.quickstarter.inf-terraform-aws.desc=Infra - AWS Terraform
+      jenkinspipeline.quickstarter.inf-terraform-aws.repo=ods-quickstarters
+
       # Other quickstarters
       jenkinspipeline.quickstarter.be-fe-mono-repo-plain.desc=FE/BE MonoRepo
       jenkinspipeline.quickstarter.be-fe-mono-repo-plain.repo=ods-quickstarters


### PR DESCRIPTION
Update the Config Map of the Prov-app with the new AWS Terraform quickstarter for master

Follow up of https://github.com/opendevstack/ods-quickstarters/pull/515
Port to master of #970

@michaelsauter @metmajer @clemensutschig @gerardcl @nichtraunzer