### PR TITLE
Install Aquasec scannercli on jenkins base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - ds-ml-service deprecated and moved to extra-quickstarters ([#568](https://github.com/opendevstack/ods-quickstarters/issues/568))
 
 ### Added
+- Install Aquasec scannercli on jenkins base image ([#976](https://github.com/opendevstack/ods-core/pull/976))
 - Add changelog enforcer as GitHub Action to workflow ([#891](https://github.com/opendevstack/ods-core/issues/891))
 - Narrow down system:authenticated permissions when creating new ODS project ([#942](https://github.com/opendevstack/ods-core/issues/942))
 - Added SonarQube test for commercial editions ([#978](https://github.com/opendevstack/ods-core/pull/978))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The extended, most up to date, user friendly documentation can be found @ [opend
 
 ## Contents
 1. [Jenkins master](jenkins/master) & base agent - the basis of the ODS build engine<br>
-The [base agent](jenkins/agent-base) provides plugins for Sonarqube, optionally Snyk, CNES, skopeo and is HTTP proxy aware.
+The [base agent](jenkins/agent-base) provides plugins for Sonarqube, optionally Snyk, AquaSec, CNES, skopeo and is HTTP proxy aware.
 Specific [quickstarters / boilerplates](https://github.com/opendevstack/ods-quickstarters/tree/master) require different technologies e.g. `gradle`, `NPM/Yarn` etc. to build, hence warrant their own `builder agents`. These `agents` are based on the ods `jenkins base agent` and are hosted in the [ods-quickstarter repository](https://github.com/opendevstack/ods-quickstarters/tree/master/common/jenkins-agents) - next to their respective [boilerplates](https://github.com/opendevstack/ods-quickstarters/tree/master). <br>During `jenkins` builds, instances/pods of those `builder / agent` images can be found within the project specific `cd` namespace.
 <br>*Deployment:* one global Jenkins instance in the central `ods` namespace
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -226,6 +226,14 @@ JENKINS_AGENT_DOCKERFILE_PATH=Dockerfile.rhel7
 # Latest tested version is v1.217.3.
 JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.217.3/snyk-linux
 
+# AquaSec CLI binary distribution url
+# Leave empty to avoid installing AquaSec.
+# Releases are published at https://download.aquasec.com/scanner
+# To Download the aquaSec scanner cli requires a valid account on aquasec.com
+# Latest tested version is 6.0.0
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
+JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
+
 # Repository of shared library
 # You may also point to repository underneath REPO_BASE.
 SHARED_LIBRARY_REPOSITORY=https://github.com/opendevstack/ods-jenkins-shared-library.git

--- a/jenkins/agent-base/Dockerfile.rhel7
+++ b/jenkins/agent-base/Dockerfile.rhel7
@@ -14,6 +14,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
+ARG AQUASEC_SCANNERCLI_URL
 
 RUN yum -y install \
     openssl \
@@ -84,6 +85,16 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
     && echo 'Snyk CLI version:' \
     && snyk --version \
     && echo 'Snyk installation completed!'; \
+    fi
+
+# Optionally install Aquasec.
+RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUASEC_SCANNERCLI_URL \
+    && wget $AQUASEC_SCANNERCLI_URL -O aquasec \
+    && mv aquasec /usr/local/bin \
+    && chmod +rwx /usr/local/bin/aquasec \
+    && echo 'AquaSec CLI version:' \
+    && aquasec version \
+    && echo 'AquaSec installation completed!'; \
     fi
 
 # Set java proxy var.

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -13,6 +13,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
+ARG AQUASEC_SCANNERCLI_URL
 
 # Add CentOS 8 repositories.
 COPY yum.repos.d/centos8.repo /etc/yum.repos.d/centos8.repo
@@ -79,6 +80,16 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
     && echo 'Snyk CLI version:' \
     && snyk --version \
     && echo 'Snyk installation completed!'; \
+    fi
+
+# Optionally install Aquasec.
+RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUASEC_SCANNERCLI_URL \
+    && wget $AQUASEC_SCANNERCLI_URL -O aquasec \
+    && mv aquasec /usr/local/bin \
+    && chmod +rwx /usr/local/bin/aquasec \
+    && echo 'AquaSec CLI version:' \
+    && aquasec version \
+    && echo 'AquaSec installation completed!'; \
     fi
 
 # Set java proxy var.

--- a/jenkins/ocp-config/build/bc.yml
+++ b/jenkins/ocp-config/build/bc.yml
@@ -50,6 +50,8 @@ parameters:
   description: OpenShift application base dns - used for grabbing the root ca and adding into the agent
 - name: JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL
   description: optional uri that points to the snyk binary distribution (i.e. https://github.com/snyk/snyk/releases/download/v1.180.1/snyk-linux)
+- name: JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL
+  description: optional uri that points to the aquasec binary distribution (i.e. https://download.aquasec.com/scanner/6.0.0/scannercli)
 - name: SONAR_EDITION
   description: SonarQube edition. One of "community", "developer", "enterprise" or "datacenter".
 - name: SONAR_VERSION
@@ -155,6 +157,8 @@ objects:
             value: ${APP_DNS}
           - name: SNYK_DISTRIBUTION_URL
             value: ${JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL}
+          - name: AQUASEC_SCANNERCLI_URL
+            value: ${JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL}
         from:
           kind: DockerImage
           name: ${JENKINS_AGENT_BASE_FROM_IMAGE}


### PR DESCRIPTION
Aquasec is installed on base image if ```JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL``` it's defined on ods-configuration

Example URL
```
#JENKINS_AGENT_BASE_AQUA_SCANNERCLI_URL=https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
```