### PR TITLE
Add sonar-apex-plugin for SonarQube Enterprise and Datacenter editions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -71,6 +71,7 @@ jobs:
     strategy:
       matrix:
         version: ['7.9', '8.2.0.32929'] # 7.9 = LTS, 8.2 = latest version
+        edition: ['community', 'enterprise']
     steps:
       -
         name: Checkout repository
@@ -82,7 +83,7 @@ jobs:
       -
         name: Run tests
         run: |
-          cd sonarqube && ./test.sh --sq-version=${{ matrix.version }}
+          cd sonarqube && ./test.sh --sq-version=${{ matrix.version }} --sq-edition=${{ matrix.edition }}
 
   nexus:
     name: Nexus tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 - Add changelog enforcer as GitHub Action to workflow ([#891](https://github.com/opendevstack/ods-core/issues/891))
 - Narrow down system:authenticated permissions when creating new ODS project ([#942](https://github.com/opendevstack/ods-core/issues/942))
+- Added SonarQube test for commercial editions ([#978](https://github.com/opendevstack/ods-core/pull/978))
 
 ## [3.0] - 2020-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add changelog enforcer as GitHub Action to workflow ([#891](https://github.com/opendevstack/ods-core/issues/891))
 - Narrow down system:authenticated permissions when creating new ODS project ([#942](https://github.com/opendevstack/ods-core/issues/942))
 - Added SonarQube test for commercial editions ([#978](https://github.com/opendevstack/ods-core/pull/978))
+- Added SonarQube apex plugin for enterprise and datacenter editions ([#977](https://github.com/opendevstack/ods-core/pull/977))
 
 ## [3.0] - 2020-08-11
 

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM adoptopenjdk/openjdk11:alpine-jre
 ARG sonarDistributionUrl
 ARG sonarVersion
 ARG APP_DNS
-ARG SONAR_EDITION
+ARG sonarEdition
 
 ENV SONARQUBE_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
@@ -69,7 +69,7 @@ ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.6/sonar-
 ADD https://github.com/Merck/sonar-r-plugin/releases/download/0.1.3/sonar-r-plugin-0.1.3.jar /opt/configuration/sonarqube/plugins/
 
 # Aditional plugins for Enterprise and Datacenter editions
-RUN if [[ "$SONAR_EDITION" == "enterprise" || "$SONAR_EDITION" == "datacenter" ]] ; \
+RUN if [[ "$sonarEdition" == "enterprise" || "$sonarEdition" == "datacenter" ]] ; \
         then wget https://binaries.sonarsource.com/CommercialDistribution/sonar-apex-plugin/sonar-apex-plugin-1.8.2.1946.jar -O /opt/configuration/sonarqube/plugins/sonar-apex-plugin-1.8.2.1946.jar ; \
     else echo No aditional plugins for developer and community editions ; fi
 

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM adoptopenjdk/openjdk11:alpine-jre
 ARG sonarDistributionUrl
 ARG sonarVersion
 ARG APP_DNS
+ARG SONAR_EDITION
 
 ENV SONARQUBE_HOME=/opt/sonarqube \
     SONARQUBE_JDBC_USERNAME=sonar \
@@ -66,6 +67,11 @@ ADD https://binaries.sonarsource.com/Distribution/sonar-php-plugin/sonar-php-plu
 ADD https://binaries.sonarsource.com/Distribution/sonar-csharp-plugin/sonar-csharp-plugin-8.6.1.17183.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.6/sonar-groovy-plugin-1.6.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/Merck/sonar-r-plugin/releases/download/0.1.3/sonar-r-plugin-0.1.3.jar /opt/configuration/sonarqube/plugins/
+
+# Aditional plugins for Enterprise and Datacenter editions
+RUN if [[ "$SONAR_EDITION" == "enterprise" || "$SONAR_EDITION" == "datacenter" ]] ; \
+        then wget https://binaries.sonarsource.com/CommercialDistribution/sonar-apex-plugin/sonar-apex-plugin-1.8.2.1946.jar -O /opt/configuration/sonarqube/plugins/sonar-apex-plugin-1.8.2.1946.jar ; \
+    else echo No aditional plugins for developer and community editions ; fi
 
 RUN chown -R :0 /opt/configuration/sonarqube/plugins; \
     chmod -R g=u /opt/configuration/sonarqube/plugins; \

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -142,7 +142,7 @@ objects:
             value: ${SONAR_DISTRIBUTION_URL}
           - name: APP_DNS
             value: ${APP_DNS}
-          - name: SONAR_EDITION
+          - name: sonarEdition
             value: ${SONAR_EDITION}
       type: Docker
     successfulBuildsHistoryLimit: 5

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -70,6 +70,8 @@ parameters:
   description: "Sonarqube distribution url. Example community edition: https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-7.3.zip"
 - name: SONAR_VERSION
   description: "Sonarqube version specified in the variable SONAR_DISTRIBUTION_URL"
+- name: SONAR_EDITION
+  description: "Sonarqube edition specified in the variable SONAR_EDITION"
 - name: SONAR_AUTH_CROWD
   description: "Set to true, if you want to use crowd as identity provider"
 - name: APP_DNS
@@ -140,6 +142,8 @@ objects:
             value: ${SONAR_DISTRIBUTION_URL}
           - name: APP_DNS
             value: ${APP_DNS}
+          - name: SONAR_EDITION
+            value: ${SONAR_EDITION}
       type: Docker
     successfulBuildsHistoryLimit: 5
 - apiVersion: v1

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -244,7 +244,7 @@ case $SONAR_EDITION in
                 "csharp:8.6.1.17183"
                 "groovy:1.6" 
                 "r:0.1.3"
-                "sonarpaex:1.8.2.1946" )
+                "sonarapex:1.8.2.1946" )
         ;;
 
     *)

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -243,7 +243,8 @@ case $SONAR_EDITION in
                 "php:3.3.0.5166"
                 "csharp:8.6.1.17183"
                 "groovy:1.6" 
-                "r:0.1.3" )
+                "r:0.1.3"
+                "sonarpaex:1.8.2.1946" )
         ;;
 
     *)

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -7,12 +7,14 @@ ODS_CORE_DIR=${SCRIPT_DIR%/*}
 ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
 SONAR_VERSION=7.9
+SONAR_EDITION="community"
 
 function usage {
     printf "Test SonarQube setup.\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
     printf "\t-s|--sq-version\t\tSonarQube version, e.g. '7.9' or '8.2.0.32929' (defaults to %s)\n" "${SONAR_VERSION}"
+    printf "\t-e|--sq-edition\t\tSonarQube edition, e.g. 'community' or 'enterprise' (defaults to %s)\n" "${SONAR_EDITION}"
     printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
     printf "\t--verify\t\tSkips setup of local docker container and instead checks existing sonarqube setup based on ods-core.env\n"
     printf "\t -n|--no-prompts\t\tDo not prompt for unknown passwords. Only used with --verify.\n"
@@ -43,6 +45,9 @@ while [[ "$#" -gt 0 ]]; do
     -s|--sq-version) SONAR_VERSION="$2"; shift;;
     -s=*|--sq-version=*) SONAR_VERSION="${1#*=}";;
 
+    -e|--sq-edition) SONAR_EDITION="$2"; shift;;
+    -e=*|--sq-edition=*) SONAR_EDITION="${1#*=}";;
+
     *) echo "Unknown parameter passed: $1"; exit 1;;
 esac; shift; done
 
@@ -50,80 +55,108 @@ if [ -z "${SONAR_VERSION}" ]; then
   echo "ERROR: Param --sq-version is missing!"; usage; exit 1;
 fi
 
+if [ -z "${SONAR_EDITION}" ]; then
+  echo "ERROR: Param --sq-edition is missing!"; usage; exit 1;
+fi
+
 ADMIN_USER_DEFAULT_PASSWORD="admin"
 
 if ! $VERIFY_ONLY; then
-    SONAR_DISTRIBUTION_URL="https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONAR_VERSION}.zip"
-    HOST_PORT="9000"
-    CONTAINER_IMAGE="sqtest"
 
-    echo "Test proxy settings"
-    rm test.properties || true
-    sh -c "HTTP_PROXY=https://foo:bar@example.com:9000 ./docker/set-proxy.sh test.properties"
-    if ! diff test.properties.fixture test.properties; then
-        echo "Proxy settings mismatch"
-        exit 1
-    fi
+    case $SONAR_EDITION in
 
-    echo "Build image"
-    docker build \
-        -t "${CONTAINER_IMAGE}" \
-        --build-arg sonarDistributionUrl="${SONAR_DISTRIBUTION_URL}" \
-        --build-arg sonarVersion="${SONAR_VERSION}" \
-        --build-arg idpDns="" \
-        ./docker
+        community)
+            SONAR_DISTRIBUTION_URL="https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${SONAR_VERSION}.zip"
+            ;;
 
-    echo "Run container using image ${CONTAINER_IMAGE}"
-    containerId=$(docker run -d --stop-timeout 3600 -p "${HOST_PORT}":9000 -p 9092:9092 "${CONTAINER_IMAGE}")
+        developer)
+            SONAR_DISTRIBUTION_URL="https://binaries.sonarsource.com/CommercialDistribution/sonarqube-developer/sonarqube-developer-${SONAR_VERSION}.zip"
+            ;;
 
-    function cleanup {
-        echo "Cleanup"
-        docker rm -f "${containerId}"
-        rm test.properties
-    }
-    trap cleanup EXIT
+        enterprise)
+            SONAR_DISTRIBUTION_URL="https://binaries.sonarsource.com/CommercialDistribution/sonarqube-enterprise/sonarqube-enterprise-${SONAR_VERSION}.zip"
+            ;;
 
-    SONARQUBE_URL="http://localhost:${HOST_PORT}"
-    SONAR_ADMIN_USERNAME="admin"
-    ADMIN_USER_DEFAULT_PASSWORD="admin"
-    ADMIN_PASSWORD="s3cr3t&C0mpl3x"
-    PIPELINE_USER_NAME="cd_user"
-    PIPELINE_USER_PWD="cd_user"
+        datacenter)
+            SONAR_DISTRIBUTION_URL="https://binaries.sonarsource.com/CommercialDistribution/sonarqube-datacenter/sonarqube-datacenter-${SONAR_VERSION}.zip"
+            ;;
 
-    echo "Wait for SonarQube to become healthy"
-    set +e
-    n=0
-    until [ $n -ge 20 ]; do
-        health=$(curl -sS ${INSECURE} --user "${SONAR_ADMIN_USERNAME}:${ADMIN_USER_DEFAULT_PASSWORD}" \
-            "${SONARQUBE_URL}/api/system/health" | jq -r .health)
-        if [ "${health}" == "GREEN" ]; then
-            echo "SonarQube is up"
-            break
-        else
-            echo "SonarQube is not up yet, waiting 10s ..."
-            sleep 10s
-            n=$((n+1))
+        *)
+            echo -n "Sonar edition provided ${SONAR_EDITION} is not valid"; exit 1;;
+
+    esac
+        
+        HOST_PORT="9000"
+        CONTAINER_IMAGE="sqtest"
+
+        echo "Test proxy settings"
+        rm test.properties || true
+        sh -c "HTTP_PROXY=https://foo:bar@example.com:9000 ./docker/set-proxy.sh test.properties"
+        if ! diff test.properties.fixture test.properties; then
+            echo "Proxy settings mismatch"
+            exit 1
         fi
-    done
-    set -e
 
-    echo "Create fake cd_user"
-    curl -X POST -sSf ${INSECURE} --user "${SONAR_ADMIN_USERNAME}:${ADMIN_USER_DEFAULT_PASSWORD}" \
-        "${SONARQUBE_URL}/api/users/create?login=${PIPELINE_USER_NAME}&name=${PIPELINE_USER_NAME}&local=true&password=${PIPELINE_USER_PWD}" > /dev/null
+        echo "Build image"
+        docker build \
+            -t "${CONTAINER_IMAGE}" \
+            --build-arg sonarDistributionUrl="${SONAR_DISTRIBUTION_URL}" \
+            --build-arg sonarVersion="${SONAR_VERSION}" \
+            --build-arg sonarEdition="${SONAR_EDITION}" \
+            --build-arg idpDns="" \
+            ./docker
 
-    echo "Run ./configure.sh"
-    prior_SONAR_AUTH_TOKEN_B64=
-    if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
-        prior_SONAR_AUTH_TOKEN_B64=$(grep SONAR_AUTH_TOKEN_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
-    fi
-    ./configure.sh \
-        --admin-password=${ADMIN_PASSWORD} \
-        --pipeline-user=${PIPELINE_USER_NAME} \
-        --sonarqube=${SONARQUBE_URL}
-    now_SONAR_AUTH_TOKEN_B64=$(grep SONAR_AUTH_TOKEN_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
-    if [ -n "$now_SONAR_AUTH_TOKEN_B64" ] && [ "$now_SONAR_AUTH_TOKEN_B64" != "$prior_SONAR_AUTH_TOKEN_B64" ]; then
-        SONAR_AUTH_TOKEN_B64="$now_SONAR_AUTH_TOKEN_B64"
-    fi
+        echo "Run container using image ${CONTAINER_IMAGE}"
+        containerId=$(docker run -d --stop-timeout 3600 -p "${HOST_PORT}":9000 -p 9092:9092 "${CONTAINER_IMAGE}")
+
+        function cleanup {
+            echo "Cleanup"
+            docker rm -f "${containerId}"
+            rm test.properties
+        }
+        trap cleanup EXIT
+
+        SONARQUBE_URL="http://localhost:${HOST_PORT}"
+        SONAR_ADMIN_USERNAME="admin"
+        ADMIN_USER_DEFAULT_PASSWORD="admin"
+        ADMIN_PASSWORD="s3cr3t&C0mpl3x"
+        PIPELINE_USER_NAME="cd_user"
+        PIPELINE_USER_PWD="cd_user"
+
+        echo "Wait for SonarQube to become healthy"
+        set +e
+        n=0
+        until [ $n -ge 20 ]; do
+            health=$(curl -sS ${INSECURE} --user "${SONAR_ADMIN_USERNAME}:${ADMIN_USER_DEFAULT_PASSWORD}" \
+                "${SONARQUBE_URL}/api/system/health" | jq -r .health)
+            if [ "${health}" == "GREEN" ]; then
+                echo "SonarQube is up"
+                break
+            else
+                echo "SonarQube is not up yet, waiting 10s ..."
+                sleep 10s
+                n=$((n+1))
+            fi
+        done
+        set -e
+
+        echo "Create fake cd_user"
+        curl -X POST -sSf ${INSECURE} --user "${SONAR_ADMIN_USERNAME}:${ADMIN_USER_DEFAULT_PASSWORD}" \
+            "${SONARQUBE_URL}/api/users/create?login=${PIPELINE_USER_NAME}&name=${PIPELINE_USER_NAME}&local=true&password=${PIPELINE_USER_PWD}" > /dev/null
+
+        echo "Run ./configure.sh"
+        prior_SONAR_AUTH_TOKEN_B64=
+        if [ -f "${ODS_CONFIGURATION_DIR}/ods-core.env" ]; then
+            prior_SONAR_AUTH_TOKEN_B64=$(grep SONAR_AUTH_TOKEN_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
+        fi
+        ./configure.sh \
+            --admin-password=${ADMIN_PASSWORD} \
+            --pipeline-user=${PIPELINE_USER_NAME} \
+            --sonarqube=${SONARQUBE_URL}
+        now_SONAR_AUTH_TOKEN_B64=$(grep SONAR_AUTH_TOKEN_B64 "${ODS_CONFIGURATION_DIR}/ods-core.env" | cut -d "=" -f 2-)
+        if [ -n "$now_SONAR_AUTH_TOKEN_B64" ] && [ "$now_SONAR_AUTH_TOKEN_B64" != "$prior_SONAR_AUTH_TOKEN_B64" ]; then
+            SONAR_AUTH_TOKEN_B64="$now_SONAR_AUTH_TOKEN_B64"
+        fi
 else
     ods_core_env_file="${ODS_CONFIGURATION_DIR}/ods-core.env"
     if [ ! -f "$ods_core_env_file" ]; then
@@ -176,20 +209,47 @@ if [ "${forceAuthentication}" != "true" ]; then
 fi
 
 echo "Check if plugins are installed in correct versions"
-expectedPlugins=( "crowd:2.1.3"
-                  "authoidc:1.1.0"
-                  "scmgit:1.9.1.1834"
-                  "java:6.2.0.21135"
-                  "jacoco:1.0.2.475"
-                  "go:1.6.0.719"
-                  "javascript:6.1.0.11503"
-                  "python:2.1.0.5269"
-                  "typescript:2.1.0.4359"
-                  "sonarscala:1.5.0.315"
-                  "php:3.3.0.5166"
-                  "csharp:8.6.1.17183"
-                  "groovy:1.6" 
-                  "r:0.1.3" )
+
+case $SONAR_EDITION in
+
+    community | developer)
+        expectedPlugins=( "crowd:2.1.3"
+                "authoidc:1.1.0"
+                "scmgit:1.9.1.1834"
+                "java:6.2.0.21135"
+                "jacoco:1.0.2.475"
+                "go:1.6.0.719"
+                "javascript:6.1.0.11503"
+                "python:2.1.0.5269"
+                "typescript:2.1.0.4359"
+                "sonarscala:1.5.0.315"
+                "php:3.3.0.5166"
+                "csharp:8.6.1.17183"
+                "groovy:1.6" 
+                "r:0.1.3" )
+        ;;
+
+    enterprise | datacenter)
+        expectedPlugins=( "crowd:2.1.3"
+                "authoidc:1.1.0"
+                "scmgit:1.9.1.1834"
+                "java:6.2.0.21135"
+                "jacoco:1.0.2.475"
+                "go:1.6.0.719"
+                "javascript:6.1.0.11503"
+                "python:2.1.0.5269"
+                "typescript:2.1.0.4359"
+                "sonarscala:1.5.0.315"
+                "php:3.3.0.5166"
+                "csharp:8.6.1.17183"
+                "groovy:1.6" 
+                "r:0.1.3" )
+        ;;
+
+    *)
+        echo -n "Sonar edition provided ${SONAR_EDITION} is not valid"; exit 1;;
+
+esac
 
 actualPlugins=$(curl -sSf ${INSECURE} \
     --user "$CURL_ADMIN_AUTH" \


### PR DESCRIPTION
This is the initial PR for the issue #975

There is an issue where this plugin gives errors when adding it to Sonar Community and Developer editions.
This plugin can only be added to Enterprise and Datacenter editions
https://docs.sonarqube.org/8.2/analysis/languages/overview/

That is why we had to make a difference between the editions and add an if statement into the dockerfile

If you have any thoughts on this please share them

@metmajer @felipecruz91 @michaelsauter @gerardcl 