### PR TITLE
Parameterize database image of SonarQube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add pub key parameter to buildbot ([#956](https://github.com/opendevstack/ods-core/pull/956))
 - Extends packer build to add a pub key as authorized key to odsbox ami image ([#953](https://github.com/opendevstack/ods-core/pull/953))
 - Add script to generate the OpenVPN client profile for the ODS in a box
+- Allow to configure database image for SonarQube ([#984](https://github.com/opendevstack/ods-core/pull/984))
 
 ### Changed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -92,6 +92,11 @@ SONAR_CROWD_APPLICATION=sonarqube
 SONAR_CROWD_PASSWORD_B64=changeme
 
 # Postgres DB for SonarQube
+# Image to use for the PostgreSQL database. This needs to be compatible with
+# your SonarQube version, see https://docs.sonarqube.org/latest/requirements/requirements/.
+# Take care when upgrading either database or SQ version.
+# E.g. registry.redhat.io/rhel8/postgresql-12
+SONAR_DATABASE_IMAGE=docker-registry.default.svc:5000/openshift/postgresql:9.6
 # Connection string for JDBC. Typically this does not need to be changed.
 SONAR_DATABASE_JDBC_URL=jdbc:postgresql://sonarqube-postgresql:5432/sonarqube
 # Database name for SonarQube. Typically this does not need to be changed.

--- a/sonarqube/ocp-config/sonarqube.yml
+++ b/sonarqube/ocp-config/sonarqube.yml
@@ -36,6 +36,10 @@ parameters:
   name: CROWD_URL
   description: url under which crowd is reachable from sonaruqbe
 - displayName: Database JDBC URL
+  name: SONAR_DATABASE_IMAGE
+  description: Image to use for the PostgreSQL database, e.g. registry.redhat.io/rhel8/postgresql-12
+  required: true
+- displayName: Database JDBC URL
   name: SONAR_DATABASE_JDBC_URL
   description: database jdbc url, e.g. jdbc:postgresql://sonarqube-postgresql:5432/sonarqube
   required: true
@@ -188,7 +192,7 @@ objects:
               configMapKeyRef:
                 key: database-name
                 name: sonarqube
-          image: ''
+          image: ${SONAR_DATABASE_IMAGE}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -241,15 +245,6 @@ objects:
             claimName: sonarqube-postgresql
     test: false
     triggers:
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - postgresql
-        from:
-          kind: ImageStreamTag
-          name: postgresql:9.6
-          namespace: openshift
-      type: ImageChange
     - type: ConfigChange
 - apiVersion: v1
   kind: DeploymentConfig


### PR DESCRIPTION
The default image is not a great solution but:

* I could not find another image provided by RedHat that works
* using 9.6 as the default ensures that the image does not change for existing installations