### PR TITLE
Use storageClassName instead of annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 - Preserve clusterIPs of services ([#983](https://github.com/opendevstack/ods-core/pull/983))
+- Use storageClassName instead of annotation ([#985](https://github.com/opendevstack/ods-core/pull/985))
 
 ### Removed
 

--- a/nexus/ocp-config/Tailorfile
+++ b/nexus/ocp-config/Tailorfile
@@ -5,5 +5,6 @@ ignore-unknown-parameters true
 preserve-immutable-fields true
 preserve pvc:/spec/volumeMode
 preserve svc:/spec/clusterIPs
+preserve pvc:/metadata/annotations/volume.beta.kubernetes.io/storage-class
 
 dc,is,pvc,route,svc

--- a/nexus/ocp-config/pvc.yml
+++ b/nexus/ocp-config/pvc.yml
@@ -21,7 +21,6 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS_DATA}
       volume.beta.kubernetes.io/storage-provisioner: ${STORAGE_PROVISIONER}
     finalizers:
     - kubernetes.io/pvc-protection
@@ -34,12 +33,12 @@ objects:
     resources:
       requests:
         storage: ${NEXUS_DATA_CAPACITY}
+    storageClassName: ${STORAGE_CLASS_DATA}
     volumeMode: Filesystem
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS_BACKUP}
       volume.beta.kubernetes.io/storage-provisioner: ${STORAGE_PROVISIONER}
     finalizers:
     - kubernetes.io/pvc-protection
@@ -52,4 +51,5 @@ objects:
     resources:
       requests:
         storage: ${NEXUS_BACKUP_CAPACITY}
+    storageClassName: ${STORAGE_CLASS_BACKUP}
     volumeMode: Filesystem

--- a/ods-provisioning-app/ocp-config/Tailorfile
+++ b/ods-provisioning-app/ocp-config/Tailorfile
@@ -4,6 +4,7 @@ param-file ../../../ods-configuration/ods-core.env
 preserve cm:quickstarters.properties:/data
 preserve pvc:/spec/volumeMode
 preserve svc:/spec/clusterIPs
+preserve pvc:/metadata/annotations/volume.beta.kubernetes.io/storage-class
 preserve-immutable-fields true
 ignore-unknown-parameters true
 

--- a/ods-provisioning-app/ocp-config/pvc.yml
+++ b/ods-provisioning-app/ocp-config/pvc.yml
@@ -16,7 +16,6 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     annotations:
-      volume.beta.kubernetes.io/storage-class: ${STORAGE_CLASS_DATA}
       volume.beta.kubernetes.io/storage-provisioner: ${STORAGE_PROVISIONER}
     finalizers:
     - kubernetes.io/pvc-protection
@@ -27,4 +26,5 @@ objects:
     resources:
       requests:
         storage: ${PROV_APP_HISTORY_CAPACITY}
+    storageClassName: ${STORAGE_CLASS_DATA}
     volumeMode: Filesystem


### PR DESCRIPTION
Otherwise the PVC resources are stuck in "pending" in an OpenShift 4.6
cluster.

Note that the SonarQube PVC resources are already defined with
`storageClassName`, and without the annotation.

Supersedes #950.