### PR TITLE
Make sure result image is public

### DIFF
--- a/ods-devenv/packer/CentOS2ODSBox.json
+++ b/ods-devenv/packer/CentOS2ODSBox.json
@@ -20,6 +20,9 @@
             "ssh_username": "{{user `username`}}",
             "ssh_password": "{{user `password`}}",
             "ami_name": "ODS in a Box {{user `ods_branch` | clean_resource_name}} {{isotime | clean_resource_name}}",
+            "ami_groups": [
+                "all"
+            ],
             "run_tags": {
                 "Name": "ODS in a Box Packer Builder {{user `ods_branch` | clean_resource_name}} {{isotime | clean_resource_name}}"
             },


### PR DESCRIPTION
This _should_ make sure the resulting image will be publicly available.

It is quite hard to test as there is no VMWare available and it will not build without the base OVA being made available as well.

Changing that might take a while as there are a bunch of assumptions in these scripts.

I'd prefer if this was based on the official CentOS images rather than a kickstarted OVA:

```diff
diff --git a/ods-devenv/packer/CentOS2ODSBox.json b/ods-devenv/packer/CentOS2ODSBox.json
index 495d849..ba517c5 100644
--- a/ods-devenv/packer/CentOS2ODSBox.json
+++ b/ods-devenv/packer/CentOS2ODSBox.json
@@ -12,9 +12,11 @@
             "region": "eu-west-1",
             "source_ami_filter": {
                 "filters": {
-                    "image-id": "{{user `ami_id`}}"
+                    "name": "CentOS 7*",
+                    "architecture": "x86_64"
                 },
-                "owners": "275438041116"
+                "owners": "125523088429",
+                "most_recent": true
             },
             "instance_type": "{{user `instance_type`}}",
             "ssh_username": "{{user `username`}}",
```

#988