### PR TITLE
Fix config check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Tailor detects drift in cluster IP addresses in OCP 4.7+ ([#683](https://github.com/opendevstack/ods-jenkins-shared-library/issues/683))
 - Jenkins plugins version for OCP 3 ([#1000](https://github.com/opendevstack/ods-core/issues/1000))
 - fix openshift templates deprecation notice ([#639](https://github.com/opendevstack/ods-quickstarters/issues/639))
+- Fix config check ([#1036](https://github.com/opendevstack/ods-core/pull/1036))
 
 ### Removed
 

--- a/ods-setup/config.sh
+++ b/ods-setup/config.sh
@@ -135,8 +135,8 @@ for i in *.env.sample; do
     echo_warn "Actual param file ${actualFile} does not exist yet and will be created. Please review its contents carefully."
     cp $i $actualFile
   else
-    sampleParams=$(cat $i | grep "[A-Z1-9_]\+=" | awk -F'=' '{print $1}')
-    actualParams=($(cat $actualFile | grep "[A-Z1-9_]\+=" | awk -F'=' '{print $1"="}'))
+    sampleParams=$(cat $i | grep "^[A-Z1-9_]\+=" | awk -F'=' '{print $1}')
+    actualParams=($(cat $actualFile | grep "^[A-Z1-9_]\+=" | awk -F'=' '{print $1"="}'))
     for sampleParam in $sampleParams; do
       if ! (elementIn "${sampleParam}=" "${actualParams[@]}"); then
         anyDrift=true


### PR DESCRIPTION
Without `^`, the check detects missing params which are actually
comments. We only want to check lines that start with a parameter.

Will backport to 4.x