### PR TITLE
Add dependency to docker.service in ods systemd service definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Update plugins.rhel7.txt ([1023](https://github.com/opendevstack/ods-core/pull/1023))
 - `make` is missing from Jenkins agent images in OpenShift 4 ([1025](https://github.com/opendevstack/ods-core/issues/1025))
 - Update ods.service in order to startup the ods service correctly ([1042](https://github.com/opendevstack/ods-core/pull/1042))
-- 
+- Add dependency to docker.service in ods systemd service definition ([1045](https://github.com/opendevstack/ods-core/pull/1045))
+
 ### Added
 - Install Aquasec scannercli on jenkins base image ([#976](https://github.com/opendevstack/ods-core/pull/976))
 - Add changelog enforcer as GitHub Action to workflow ([#891](https://github.com/opendevstack/ods-core/issues/891))

--- a/ods-devenv/ods-service/ods.service
+++ b/ods-devenv/ods-service/ods.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Start and stop ODS service gracefully on machine boot and shutdown
-After=network-online.target
+After=network-online.target docker.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
In order to try to start up properly ODS we need to add a dependency with docker as it is not alway available when ODS is starting