### PR TITLE
fix #1116: add plugins to ubi8 jenkins managed plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add support for ods-saas-service quickstarter ([#1033](https://github.com/opendevstack/ods-core/pull/1033))
 - ODS AMI build failing due to broken helm diff package ([#1083](https://github.com/opendevstack/ods-core/pull/1083))
 - ODS AMI CI build fails with Prov APP (ocp check precondition) ([#1117](https://github.com/opendevstack/ods-core/pull/1117))
+- Add plugins necessary to upgrade to 4.9 base image in the list of managed plugins ([#1121](https://github.com/opendevstack/ods-core/pull/1121))
 
 ### Added
 

--- a/jenkins/master/plugins.ubi8.txt
+++ b/jenkins/master/plugins.ubi8.txt
@@ -4,3 +4,8 @@ sonar:2.6.1
 ansicolor:0.7.0
 blueocean:1.18.0
 audit-trail:3.10
+parameterized-trigger:2.39
+pipeline-rest-api:2.15
+workflow-cps-global-lib:2.17
+junit:1.53
+token-macro:267.vcdaea6462991


### PR DESCRIPTION
Add plugins necessary to upgrade to 4.9 base image in the list of managed plugins