### PR TITLE
Point aqua credential id to project-specific cd user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Do not replace multiple occurences of project in component name ([#1078](https://github.com/opendevstack/ods-core/issues/1078))
 - Jenkins Agent Base UBI8 fix new Centos repos ([#1093](https://github.com/opendevstack/ods-core/pull/1093))
 - Update centos mirror ([#1098](https://github.com/opendevstack/ods-core/pull/1098))
+- Point Aqua credential id to project-specific CD user ([#1125](https://github.com/opendevstack/ods-core/issues/1125))
 
 ### Removed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -388,7 +388,7 @@ AQUA_URL=
 AQUA_REGISTRY=
 
 # The name of a secret containing credentials (username and password) of an Aqua user that has scanner rights
-AQUA_SECRET_NAME=aqua-user-with-password
+AQUA_SECRET_NAME=cd-user-with-password
 
 # Comma separated list of email addresses to provide feedback in case there are problems using Aqua
 AQUA_ALERT_EMAILS=


### PR DESCRIPTION
fixes https://github.com/opendevstack/ods-core/issues/1125

@jorge-romero I don't know what side effects this change might have beside the impact on the issue mentioned above. Maybe you can help with that 🙂