### PR TITLE
Fix permissions where existing subdirectories might exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Needed changes to run CI again, ported from task/upgrade-atlassian-stack. Run quickstarters in parallel, typos.
 - Fixes Default jdk is not set in edpBox ([#1157](https://github.com/opendevstack/ods-core/pull/1157))
 - Allow to choose the order in which quickstaters are build ([#1158](https://github.com/opendevstack/ods-core/pull/1158))
+- Fix and prevent permission issues ([#1162](https://github.com/opendevstack/ods-core/issues/1162))
 
 ### Added
 

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -115,8 +115,8 @@ RUN yum install -y \
     && skopeo --version
 
 # Fix permissions.
-RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config \
-    && mkdir -p /home/jenkins/.cache && chmod g+w /home/jenkins/.cache \
-    && mkdir -p /home/jenkins/.sonar && chmod g+w /home/jenkins/.sonar
+RUN mkdir -p /home/jenkins/.config && chmod -R g+w /home/jenkins/.config \
+    && mkdir -p /home/jenkins/.cache && chmod -R g+w /home/jenkins/.cache \
+    && mkdir -p /home/jenkins/.sonar && chmod -R g+w /home/jenkins/.sonar
 
 RUN chmod g+w $JAVA_HOME/lib/security/cacerts

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -109,8 +109,8 @@ RUN yum install -y skopeo \
     && skopeo --version
 
 # Fix permissions.
-RUN mkdir -p /home/jenkins/.config && chmod g+w /home/jenkins/.config \
-    && mkdir -p /home/jenkins/.cache && chmod g+w /home/jenkins/.cache \
-    && mkdir -p /home/jenkins/.sonar && chmod g+w /home/jenkins/.sonar
+RUN mkdir -p /home/jenkins/.config && chmod -R g+w /home/jenkins/.config \
+    && mkdir -p /home/jenkins/.cache && chmod -R g+w /home/jenkins/.cache \
+    && mkdir -p /home/jenkins/.sonar && chmod -R g+w /home/jenkins/.sonar 
 
 RUN chmod g+w $JAVA_HOME/lib/security/cacerts


### PR DESCRIPTION
The issue is /home/jenkins/.cache/helm directory already exists and the command to fix permissions wasn't recursive.

resolves #1162 