### PR TITLE
Removes jcenter from jenkins repos list.

### DIFF
--- a/jenkins/master/configuration/grapeConfig.xml
+++ b/jenkins/master/configuration/grapeConfig.xml
@@ -11,7 +11,6 @@
       <ibiblio name="nexus" m2compatible="true" root="${nexus-public}"/>
       <ibiblio name="localm2" root="file:${user.home}/.m2/repository/" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true"/>
       <!-- todo add 'endorsed groovy extensions' resolver here -->
-      <ibiblio name="jcenter" root="https://jcenter.bintray.com/" m2compatible="true"/>
       <ibiblio name="ibiblio" m2compatible="true"/>
     </chain>
   </resolvers>


### PR DESCRIPTION
Fixes:
- [x] https://github.com/opendevstack/ods-quickstarters/issues/804

Related PRs:
- [x] https://github.com/opendevstack/ods-core/pull/1154
- [x] https://github.com/opendevstack/ods-core/pull/1155
