### PR TITLE
Update Aqua CLI version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Allow to choose the order in which quickstaters are build ([#1158](https://github.com/opendevstack/ods-core/pull/1158))
 - Fix and prevent permission issues ([#1162](https://github.com/opendevstack/ods-core/issues/1162))
 - Fixes Jenkins Memory problems reported ([#1161](https://github.com/opendevstack/ods-core/pull/1161))
+- Update Aqua CLI version ([#1173](https://github.com/opendevstack/ods-core/pull/1173))
 
 ### Added
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -233,9 +233,10 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # AquaSec CLI binary distribution url
 # Leave empty to avoid installing AquaSec.
 # Releases are published at https://download.aquasec.com/scanner
-# To Download the aquaSec scanner cli requires a valid account on aquasec.com
-# Latest tested version is 6.0.0
-# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/6.0.0/scannercli
+# Check Aqua versions backward compatibility  at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
+# To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
+# Latest tested version is 2022.4.98
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.98/scannercli
 JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 # Repository of shared library

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -233,7 +233,7 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # AquaSec CLI binary distribution url
 # Leave empty to avoid installing AquaSec.
 # Releases are published at https://download.aquasec.com/scanner
-# Check Aqua versions backward compatibility  at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
+# Check Aqua versions backward compatibility at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
 # To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
 # Latest tested version is 2022.4.98
 # Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.98/scannercli


### PR DESCRIPTION
Update Aqua version to 2022.4.98
We can update after fixing [#875](https://github.com/opendevstack/ods-jenkins-shared-library/issues/875)

![image](https://user-images.githubusercontent.com/26645694/185627243-5b3476c3-420b-41bd-9ff4-10f84114d993.png)
