### PR TITLE
Removes existing differences between jenkins agent base image in Centos 7 and UBI 8 

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -122,7 +122,7 @@ jobs:
         name: Download golangci-lint
         run: |
           curl -sSfL --output /tmp/golangci-lint.sh https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-          cat /tmp/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+          cat /tmp/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0
       -
         name: Run linter
         working-directory: jenkins/webhook-proxy
@@ -201,7 +201,7 @@ jobs:
         name: Verify all Go tests pass linting
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.49.0
           working-directory: tests
           args: --timeout=10m
       -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Update Aqua CLI version ([#1173](https://github.com/opendevstack/ods-core/pull/1173))
 - Fix CI/CD problems in Jenkins pipelines ([#1177](https://github.com/opendevstack/ods-core/pull/1177))
 - Fixes Python agent does not seems to have java in the path ([#685](https://github.com/opendevstack/ods-quickstarters/issues/685)) 
+- Removes existing differences between jenkins agent base image in Centos 7 and UBI 8 ([#1181](https://github.com/opendevstack/ods-core/pull/1181))
 
 ### Added
 

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -44,7 +44,7 @@ RUN import_certs.sh
 
 # Install Sonar Scanner.
 RUN cd /tmp \
-    && curl -LOv https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
+    && curl -sSLOv https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli \
     && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
@@ -53,14 +53,14 @@ ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -Lv https://github.com/cnescatlab/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar -o cnesreport.jar \
+    && curl -sSLv https://github.com/cnescatlab/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar -o cnesreport.jar \
     && mkdir /usr/local/cnes \
     && mv cnesreport.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar
 
 # Install Tailor.
 RUN cd /tmp \
-    && curl -LOv https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
+    && curl -sSLOv https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
     && mv tailor-linux-amd64 /usr/local/bin/tailor \
     && chmod a+x /usr/local/bin/tailor \
     && tailor version
@@ -68,7 +68,7 @@ RUN cd /tmp \
 # Install Helm.
 RUN cd /tmp \
     && mkdir -p /tmp/helm \
-    && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+    && curl -sSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz -C /tmp/helm \
     && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
     && chmod a+x /usr/local/bin/helm \
@@ -81,7 +81,7 @@ RUN cd /tmp \
 # Install GIT-LFS extension https://git-lfs.github.com/.
 RUN cd /tmp \
     && mkdir -p /tmp/git-lfs \
-    && curl -LOv https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz \
+    && curl -sSLOv https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz \
     && tar -zxvf git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz -C /tmp/git-lfs \
     && bash /tmp/git-lfs/install.sh \
     && git lfs version \
@@ -89,7 +89,7 @@ RUN cd /tmp \
 
 # Optionally install snyk.
 RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ; else echo 'Installing snyk... getting binary from' $SNYK_DISTRIBUTION_URL \
-    && curl -Lv $SNYK_DISTRIBUTION_URL --output snyk \
+    && curl -sSLv $SNYK_DISTRIBUTION_URL --output snyk \
     && mv snyk /usr/local/bin \
     && chmod +rwx /usr/local/bin/snyk \
     && mkdir -p $HOME/.config/configstore/ \
@@ -101,7 +101,7 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
 
 # Optionally install Aquasec.
 RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUASEC_SCANNERCLI_URL \
-    && wget $AQUASEC_SCANNERCLI_URL -O aquasec \
+    && curl -sSL $AQUASEC_SCANNERCLI_URL --output aquasec \
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -10,7 +10,10 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     HELM_PLUGIN_SECRETS_VERSION=3.3.5 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
-    OSTREE_VERSION=2018.5-1
+    OSTREE_VERSION=2018.5-1 \
+    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled \
+                      -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions \
+                      -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
@@ -20,7 +23,9 @@ ENV JAVA_HOME=/usr/lib/jvm/jre
 
 RUN rm -fv /etc/yum.repos.d/CentOS-Media.repo /etc/yum.repos.d/origin-local-release.repo \
     && yum -y install openssl \
-    && yum -y install java-1.8.0-openjdk-devel.x86_64 java-11-openjdk-devel \
+    && yum -y install java-11-openjdk-devel \
+    && yum list installed | grep java \
+    && yum -y remove java-1.8* \
     && yum -y update \
     && yum clean all \
     && rm -rf /var/cache/yum/*
@@ -110,9 +115,18 @@ RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation
 COPY set_java_proxy.sh /tmp/set_java_proxy.sh
 RUN . /tmp/set_java_proxy.sh && echo $JAVA_OPTS
 
+# The following line fix incorrect behaviours in the base image.
+# It is setting the variable JAVA_TOOL_OPTIONS while it should not.
+# Besides, we need to know if this variable has not been set.
+# It is a problem very difficult to detect...
 RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
     && sed -i 's|\#\!/bin/bash|\#\!/bin/bash -x|g' /usr/local/bin/openshift-run-jnlp-client \
-    && head -n 10 /usr/local/bin/openshift-run-jnlp-client
+    && sed -i "s|^\s*JAVA_TOOL_OPTIONS\s*=.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+        /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+        /usr/local/bin/openshift-run-jnlp-client \
+    && head -n 10 /usr/local/bin/openshift-run-jnlp-client \
+    && grep -i 'JAVA_TOOL_OPTIONS' /usr/local/bin/openshift-run-jnlp-client
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -110,7 +110,9 @@ RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation
 COPY set_java_proxy.sh /tmp/set_java_proxy.sh
 RUN . /tmp/set_java_proxy.sh && echo $JAVA_OPTS
 
-RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client
+RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i 's|\#\!/bin/bash|\#\!/bin/bash -x|g' /usr/local/bin/openshift-run-jnlp-client \
+    && head -n 10 /usr/local/bin/openshift-run-jnlp-client
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -119,12 +119,13 @@ RUN . /tmp/set_java_proxy.sh && echo $JAVA_OPTS
 # It is a problem very difficult to detect...
 RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
     && sed -i 's|\#\!/bin/bash|\#\!/bin/bash -x|g' /usr/local/bin/openshift-run-jnlp-client \
-    && sed -i "s|^\s*JAVA_TOOL_OPTIONS\s*=.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+    && sed -i "s|^\s*JAVA_TOOL_OPTIONS\s*=.*|    echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
         /usr/local/bin/openshift-run-jnlp-client \
-    && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+    && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|    echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
         /usr/local/bin/openshift-run-jnlp-client \
-    && head -n 10 /usr/local/bin/openshift-run-jnlp-client \
-    && grep -i 'JAVA_TOOL_OPTIONS' /usr/local/bin/openshift-run-jnlp-client
+    && sed 's|^\(\s*\)JAVA_GC_OPTS\s*=.*|\1JAVA_GC_OPTS=|g' /usr/local/bin/openshift-run-jnlp-client \
+    && grep -B 3 -A 3 -i '\(bash\|JAVA_TOOL_OPTIONS\|JAVA_GC_OPTS\)' /usr/local/bin/openshift-run-jnlp-client
+
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -11,7 +11,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
     OSTREE_VERSION=2018.5-1 \
-    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+    JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -11,9 +11,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     GIT_LFS_VERSION=2.6.1 \
     SKOPEO_VERSION=0.1.37-3 \
     OSTREE_VERSION=2018.5-1 \
-    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled \
-                      -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions \
-                      -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL

--- a/jenkins/agent-base/Dockerfile.centos7
+++ b/jenkins/agent-base/Dockerfile.centos7
@@ -123,7 +123,7 @@ RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
         /usr/local/bin/openshift-run-jnlp-client \
     && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|    echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
         /usr/local/bin/openshift-run-jnlp-client \
-    && sed 's|^\(\s*\)JAVA_GC_OPTS\s*=.*|\1JAVA_GC_OPTS=|g' /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i 's|^\(\s*\)JAVA_GC_OPTS\s*=.*|\1JAVA_GC_OPTS=|g' /usr/local/bin/openshift-run-jnlp-client \
     && grep -B 3 -A 3 -i '\(bash\|JAVA_TOOL_OPTIONS\|JAVA_GC_OPTS\)' /usr/local/bin/openshift-run-jnlp-client
 
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -9,7 +9,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGIN_SECRETS_VERSION=3.3.5 \
     GIT_LFS_VERSION=2.6.1 \
-    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+    JAVA_TOOL_OPTIONS="-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true"
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -116,12 +116,13 @@ RUN . /tmp/set_java_proxy.sh && echo $JAVA_OPTS
 # Customize entrypoint.
 RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
     && sed -i 's|\#\!/bin/bash|\#\!/bin/bash -x|g' /usr/local/bin/openshift-run-jnlp-client \
-    && sed -i "s|^\s*JAVA_TOOL_OPTIONS\s*=.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+    && sed -i "s|^\s*JAVA_TOOL_OPTIONS\s*=.*|    echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
         /usr/local/bin/openshift-run-jnlp-client \
-    && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+    && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|    echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
         /usr/local/bin/openshift-run-jnlp-client \
-    && head -n 10 /usr/local/bin/openshift-run-jnlp-client \
-    && grep -i 'JAVA_TOOL_OPTIONS' /usr/local/bin/openshift-run-jnlp-client
+    && sed 's|^\(\s*\)JAVA_GC_OPTS\s*=.*|\1JAVA_GC_OPTS=|g' /usr/local/bin/openshift-run-jnlp-client \
+    && grep -B 3 -A 3 -i '\(bash\|JAVA_TOOL_OPTIONS\|JAVA_GC_OPTS\)' /usr/local/bin/openshift-run-jnlp-client
+
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -120,7 +120,7 @@ RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
         /usr/local/bin/openshift-run-jnlp-client \
     && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|    echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
         /usr/local/bin/openshift-run-jnlp-client \
-    && sed 's|^\(\s*\)JAVA_GC_OPTS\s*=.*|\1JAVA_GC_OPTS=|g' /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i 's|^\(\s*\)JAVA_GC_OPTS\s*=.*|\1JAVA_GC_OPTS=|g' /usr/local/bin/openshift-run-jnlp-client \
     && grep -B 3 -A 3 -i '\(bash\|JAVA_TOOL_OPTIONS\|JAVA_GC_OPTS\)' /usr/local/bin/openshift-run-jnlp-client
 
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -8,7 +8,10 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     HELM_VERSION=3.5.3 \
     HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGIN_SECRETS_VERSION=3.3.5 \
-    GIT_LFS_VERSION=2.6.1
+    GIT_LFS_VERSION=2.6.1 \
+    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled \
+                      -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions \
+                      -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL
@@ -113,7 +116,14 @@ COPY set_java_proxy.sh /tmp/set_java_proxy.sh
 RUN . /tmp/set_java_proxy.sh && echo $JAVA_OPTS
 
 # Customize entrypoint.
-RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client
+RUN mv /usr/local/bin/run-jnlp-client /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i 's|\#\!/bin/bash|\#\!/bin/bash -x|g' /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i "s|^\s*JAVA_TOOL_OPTIONS\s*=.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+        /usr/local/bin/openshift-run-jnlp-client \
+    && sed -i "s|^\s*export\s*JAVA_TOOL_OPTIONS.*|echo 'WARNING: JAVA_TOOL_OPTIONS env variable is UNSET.'|g" \
+        /usr/local/bin/openshift-run-jnlp-client \
+    && head -n 10 /usr/local/bin/openshift-run-jnlp-client \
+    && grep -i 'JAVA_TOOL_OPTIONS' /usr/local/bin/openshift-run-jnlp-client
 COPY ods-run-jnlp-client.sh /usr/local/bin/run-jnlp-client
 
 # Add skopeo.

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -9,9 +9,7 @@ ENV SONAR_SCANNER_VERSION=3.1.0.1141 \
     HELM_PLUGIN_DIFF_VERSION=3.3.2 \
     HELM_PLUGIN_SECRETS_VERSION=3.3.5 \
     GIT_LFS_VERSION=2.6.1 \
-    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled \
-                      -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions \
-                      -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+    JAVA_TOOL_OPTIONS=-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+UnlockDiagnosticVMOptions -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
 
 ARG APP_DNS
 ARG SNYK_DISTRIBUTION_URL

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -43,7 +43,7 @@ RUN import_certs.sh
 
 # Install Sonar Scanner.
 RUN cd /tmp \
-    && curl -LO https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
+    && curl -sSLO https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_SCANNER_VERSION}/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
     && mv sonar-scanner-${SONAR_SCANNER_VERSION} /usr/local/sonar-scanner-cli \
     && rm -rf sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
@@ -52,14 +52,14 @@ ENV PATH=/usr/local/sonar-scanner-cli/bin:$PATH
 
 # Add sq cnes report jar.
 RUN cd /tmp \
-    && curl -L https://github.com/cnescatlab/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar -o cnesreport.jar \
+    && curl -sSL https://github.com/cnescatlab/sonar-cnes-report/releases/download/${CNES_REPORT_VERSION}/sonar-cnes-report-${CNES_REPORT_VERSION}.jar -o cnesreport.jar \
     && mkdir /usr/local/cnes \
     && mv cnesreport.jar /usr/local/cnes/cnesreport.jar \
     && chmod 777 /usr/local/cnes/cnesreport.jar
 
 # Install Tailor.
 RUN cd /tmp \
-    && curl -LO https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
+    && curl -sSLO https://github.com/opendevstack/tailor/releases/download/v${TAILOR_VERSION}/tailor-linux-amd64 \
     && mv tailor-linux-amd64 /usr/local/bin/tailor \
     && chmod a+x /usr/local/bin/tailor \
     && tailor version
@@ -67,7 +67,7 @@ RUN cd /tmp \
 # Install Helm.
 RUN cd /tmp \
     && mkdir -p /tmp/helm \
-    && curl -LO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
+    && curl -sSLO https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz \
     && tar -zxvf helm-v${HELM_VERSION}-linux-amd64.tar.gz -C /tmp/helm \
     && mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm \
     && chmod a+x /usr/local/bin/helm \
@@ -81,7 +81,7 @@ RUN cd /tmp \
 # Install GIT-LFS extension https://git-lfs.github.com/.
 RUN cd /tmp \
     && mkdir -p /tmp/git-lfs \
-    && curl -LO https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz \
+    && curl -sSLO https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz \
     && tar -zxvf git-lfs-linux-amd64-v${GIT_LFS_VERSION}.tar.gz -C /tmp/git-lfs \
     && bash /tmp/git-lfs/install.sh \
     && git lfs version \
@@ -89,7 +89,7 @@ RUN cd /tmp \
 
 # Optionally install snyk.
 RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ; else echo 'Installing snyk... getting binary from' $SNYK_DISTRIBUTION_URL \
-    && curl -L $SNYK_DISTRIBUTION_URL --output snyk \
+    && curl -sSL $SNYK_DISTRIBUTION_URL --output snyk \
     && mv snyk /usr/local/bin \
     && chmod +rwx /usr/local/bin/snyk \
     && mkdir -p $HOME/.config/configstore/ \
@@ -101,7 +101,7 @@ RUN if [ -z $SNYK_DISTRIBUTION_URL ] ; then echo 'Skipping snyk installation!' ;
 
 # Optionally install Aquasec.
 RUN if [ -z $AQUASEC_SCANNERCLI_URL ] ; then echo 'Skipping AquaSec installation!' ; else echo 'Installing AquaSec... getting binary from' $AQUASEC_SCANNERCLI_URL \
-    && wget $AQUASEC_SCANNERCLI_URL -O aquasec \
+    && curl -sSL $AQUASEC_SCANNERCLI_URL --output aquasec \
     && mv aquasec /usr/local/bin \
     && chmod +rwx /usr/local/bin/aquasec \
     && echo 'AquaSec CLI version:' \

--- a/jenkins/agent-base/ods-run-jnlp-client.sh
+++ b/jenkins/agent-base/ods-run-jnlp-client.sh
@@ -5,7 +5,9 @@ set -ue
 JAVA_HOME=${JAVA_HOME:-""}
 
 if [ -f /etc/profile.d/set-default-java.sh ]; then
+    set -x
     source /etc/profile.d/set-default-java.sh
+    set +x
 else
     echo "WARNING: Not setting default java version."
 fi

--- a/jenkins/master/configuration/init.groovy.d/flow-durability-hint.groovy
+++ b/jenkins/master/configuration/init.groovy.d/flow-durability-hint.groovy
@@ -1,3 +1,4 @@
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.flow.*;
 
 // See comments in https://github.com/opendevstack/ods-core/pull/1161
@@ -11,8 +12,9 @@ for (FlowDurabilityHint maybeHint : FlowDurabilityHint.values()) {
 println("\nPrevious value: ")
 println(GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint())
 
+// https://javadoc.jenkins.io/jenkins/model/class-use/Jenkins.html
 Jenkins j = Jenkins.getInstanceOrNull()
-def global_settings = j.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0).durabilityHint = fdh;
+j.getExtensionList(GlobalDefaultFlowDurabilityLevel.DescriptorImpl.class).get(0).durabilityHint = fdh;
 
 println("\nConfigured value: ")
 println(GlobalDefaultFlowDurabilityLevel.getDefaultDurabilityHint())

--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -787,7 +787,11 @@ func getSecureClient() (*http.Client, error) {
 		Certificates: []tls.Certificate{},
 		RootCAs:      caCertPool,
 	}
-	tlsConfig.BuildNameToCertificate()
+	// Deprecated.
+	// The Config.NameToCertificate field, which only supports associating a
+	// single certificate with a give name, is now deprecated and should be
+	// left as nil. https://go.dev/pkg/crypto/tls/
+	// tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
 	return &http.Client{Transport: transport, Timeout: 10 * time.Second}, nil
 }

--- a/ods-devenv/scripts/deploy.sh
+++ b/ods-devenv/scripts/deploy.sh
@@ -2161,15 +2161,18 @@ function install_ods_project() {
 function setup_nexus() {
     echo "make install-nexus: / apply-nexus:"
     pushd nexus/ocp-config
-    tailor apply --namespace "${NAMESPACE}" bc,is --non-interactive --verbose
+    tailor apply --namespace "${NAMESPACE}" bc,is --non-interactive
+    # --verbose
     popd
 
     echo "start-nexus-build:"
-    ocp-scripts/start-and-follow-build.sh --namespace "${NAMESPACE}" --build-config nexus --verbose
+    ocp-scripts/start-and-follow-build.sh --namespace "${NAMESPACE}" --build-config nexus
+    # --verbose
 
     echo "apply-nexus-deploy:"
     pushd nexus/ocp-config
-    tailor apply --namespace "${NAMESPACE}" --exclude bc,is --non-interactive --verbose
+    tailor apply --namespace "${NAMESPACE}" --exclude bc,is --non-interactive
+    # --verbose
     popd
 
     echo "make configure-nexus:"
@@ -2180,7 +2183,8 @@ function setup_nexus() {
     nexus_port=$(oc -n ods get route nexus -ojsonpath='{.spec.port.targetPort}')
     nexus_port=${nexus_port%-*} # truncate -tcp from 8081-tcp
 
-    ./configure.sh --namespace ods --nexus="${nexus_url}" --insecure --verbose --admin-password openshift
+    ./configure.sh --namespace ods --nexus="${nexus_url}" --insecure --admin-password openshift
+    # --verbose
     popd
 }
 
@@ -2198,11 +2202,13 @@ function setup_sonarqube() {
     sudo sysctl -w vm.max_map_count=262144
     echo "apply-sonarqube-build:"
     pushd sonarqube/ocp-config
-    tailor apply --namespace ${NAMESPACE} bc,is --non-interactive --verbose
+    tailor apply --namespace ${NAMESPACE} bc,is --non-interactive
+    # --verbose
     popd
 
     echo "start-sonarqube-build:"
-    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config sonarqube --verbose
+    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config sonarqube
+    # --verbose
     return_value=$?
     if [[ "${return_value}" != "0" ]]; then
         echo "start-sonarqube-build failed."
@@ -2211,7 +2217,8 @@ function setup_sonarqube() {
 
     echo "apply-sonarqube-deploy:"
     pushd sonarqube/ocp-config
-    tailor apply --namespace ${NAMESPACE} --exclude bc,is --non-interactive --verbose
+    tailor apply --namespace ${NAMESPACE} --exclude bc,is --non-interactive
+    # --verbose
     local sonarqube_url
     sonarqube_url=$(oc -n ${NAMESPACE} get route sonarqube --template 'http{{if .spec.tls}}s{{end}}://{{.spec.host}}')
     echo "Visit ${sonarqube_url}/setup to see if any update actions need to be taken."
@@ -2219,11 +2226,12 @@ function setup_sonarqube() {
 
     echo "configure-sonarqube:"
     pushd sonarqube
-    ./configure.sh --sonarqube="${sonarqube_url}" --verbose --insecure \
+    ./configure.sh --sonarqube="${sonarqube_url}" --insecure \
         --pipeline-user openshift \
         --pipeline-user-password openshift \
         --admin-password openshift \
         --write-to-config
+    # --verbose
     popd
 
     # retrieve sonar qube tokens from where configure.sh has put them
@@ -2244,7 +2252,11 @@ function setup_sonarqube() {
 #   None
 #######################################
 function setup_jenkins() {
-    echo "Setting up Jenkins"
+    echo " "
+    echo "**********************"
+    echo "* Setting up Jenkins *"
+    echo "**********************"
+    echo " "
     oc policy add-role-to-user edit -z jenkins -n ${NAMESPACE}
 
     echo "make apply-jenkins-build:"
@@ -2253,9 +2265,9 @@ function setup_jenkins() {
     popd
 
     echo "make start-jenkins-build:"
-    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config jenkins-master --verbose &
-    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config jenkins-agent-base --verbose &
-    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config jenkins-webhook-proxy --verbose &
+    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config jenkins-master --verbose
+    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config jenkins-agent-base --verbose
+    ocp-scripts/start-and-follow-build.sh --namespace ${NAMESPACE} --build-config jenkins-webhook-proxy --verbose
 
     local fail_count=0
     for job in $(jobs -p)

--- a/tests/quickstarter-test.sh
+++ b/tests/quickstarter-test.sh
@@ -49,8 +49,8 @@ echo "${THIS_SCRIPT}: Running tests (${QUICKSTARTER}). Output will take a while 
 echo " "
 
 # Should fix error " panic: test timed out after "
-echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 5h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER}"
-go test -v -count=1 -timeout 5h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER} | tee test-quickstarter-results.txt 2>&1
+echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 10h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER}"
+go test -v -count=1 -timeout 10h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER} | tee test-quickstarter-results.txt 2>&1
 exitcode="${PIPESTATUS[0]}"
 if [ -f test-quickstarter-results.txt ]; then
     go-junit-report < test-quickstarter-results.txt > test-quickstarter-report.xml

--- a/tests/quickstarter-test.sh
+++ b/tests/quickstarter-test.sh
@@ -49,8 +49,8 @@ echo "${THIS_SCRIPT}: Running tests (${QUICKSTARTER}). Output will take a while 
 echo " "
 
 # Should fix error " panic: test timed out after "
-echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 10h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER}"
-go test -v -count=1 -timeout 10h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER} | tee test-quickstarter-results.txt 2>&1
+echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 30h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER}"
+go test -v -count=1 -timeout 30h -parallel ${PARALLEL} github.com/opendevstack/ods-core/tests/quickstarter -args ${QUICKSTARTER} | tee test-quickstarter-results.txt 2>&1
 exitcode="${PIPESTATUS[0]}"
 if [ -f test-quickstarter-results.txt ]; then
     go-junit-report < test-quickstarter-results.txt > test-quickstarter-report.xml

--- a/tests/scripts/print-jenkins-json-status.sh
+++ b/tests/scripts/print-jenkins-json-status.sh
@@ -7,7 +7,7 @@ oc get build $1 -n $2 \
     -ojsonpath='{.metadata.annotations.openshift\.io/jenkins-status-json}' \
     | jq '[.stages[] | {stage: .name, status: .status}]' || OC_ERROR="true"
 
-if [ "false" == "${OC_ERROR}" ]; then
+if [ "false" != "${OC_ERROR}" ]; then
     echo " "
     echo "ERROR: Could not get oc build status named $1 in namespace $2 !!! "
     echo " "

--- a/tests/scripts/print-jenkins-json-status.sh
+++ b/tests/scripts/print-jenkins-json-status.sh
@@ -2,6 +2,14 @@
 set -eu
 set -o pipefail
 
+OC_ERROR="false"
 oc get build $1 -n $2 \
     -ojsonpath='{.metadata.annotations.openshift\.io/jenkins-status-json}' \
-    | jq '[.stages[] | {stage: .name, status: .status}]'
+    | jq '[.stages[] | {stage: .name, status: .status}]' || OC_ERROR="true"
+
+if [ "false" == "${OC_ERROR}" ]; then
+    echo " "
+    echo "ERROR: Could not get oc build status named $1 in namespace $2 !!! "
+    echo " "
+fi
+

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -5,6 +5,7 @@ set -o pipefail
 ME="$(basename $0)"
 JENKINS_LOG_FILE="jenkins-downloaded-log.txt"
 JENKINS_SERVER_LOG_FILE="jenkins-server-log.txt"
+WAIT_FOR_MANUAL_INTERVENTION="true"
 
 echo " "
 echo " "
@@ -45,6 +46,10 @@ sleep 5
 if [ -f ${JENKINS_SERVER_LOG_FILE} ]; then
     rm -fv ${JENKINS_SERVER_LOG_FILE} || echo "Problem removing existing log file (${JENKINS_SERVER_LOG_FILE})."
 fi
+
+# Does not work :-(
+# oc login -u developer -p anypwd
+# TOKEN=$(oc -n ${PROJECT} get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc -n ${PROJECT} get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | head -n 1 | base64 -d -)
 
 JENKINS_SERVER_PROTOCOL="$(echo ${LOG_URL} | cut -d "/" -f 1)"
 JENKINS_SERVER_HOSTNAME="$(echo ${LOG_URL} | cut -d "/" -f 3)"
@@ -91,9 +96,14 @@ if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${NO_SERVER_LOGS}" ] || [ "tru
     echo "A problem was found while retrieving Jenkins job/server logs."
     echo "Since we might need to enter the box and see what went wrong, this pipeline will wait for manual intervention. "
     echo "Enjoy..."
+    WAIT_FOR_MANUAL_INTERVENTION="true"
+fi
+
+if [ "true" == "${WAIT_FOR_MANUAL_INTERVENTION}" ]; then
+    echo " "
+    echo "WAITING FOR MANUAL INTERVENTION ( WAIT_FOR_MANUAL_INTERVENTION = true ) "
     echo "sleep 72000 ( 20h )"
+    echo " "
+    echo " "
     sleep 72000
-    echo " "
-    echo " "
-    echo " "
 fi

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -95,9 +95,9 @@ fi
 
 BAD_SERVER_LOGS="false"
 if grep -q 'Still waiting to schedule task' ${JENKINS_LOG_FILE} ; then
-#    if grep -q 'HTTP ERROR' ${JENKINS_SERVER_LOG_FILE} ; then
+    if ! grep -q 'Finished: SUCCESS' ${JENKINS_LOG_FILE} ; then
         BAD_SERVER_LOGS="true"
-#    fi
+    fi
 fi
 
 echo " "
@@ -106,8 +106,11 @@ echo "${ME}: NO_JOB_LOGS=${NO_JOB_LOGS}"
 echo "${ME}: BAD_SERVER_LOGS=${BAD_SERVER_LOGS}"
 echo " "
 if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${BAD_SERVER_LOGS}" ]; then
+    echo " "
     echo "${ME}: ERROR: Logs retrieved are not good enough."
-    exit 1
+    echo " "
+    # WARNING: If we exit 1, the whole process aborts !!!
+    # exit 1
 fi
 
 exit 0

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 ME="$(basename $0)"
 JENKINS_LOG_FILE="jenkins-downloaded-log.txt"
+JENKINS_SERVER_LOG_FILE="jenkins-server-log.txt"
 
 echo " "
 echo " "
@@ -17,7 +18,7 @@ echo " "
 TOKEN=$(oc -n ${PROJECT} get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc -n ${PROJECT} get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | head -n 1 | base64 -d -)
 
 if [ -f ${JENKINS_LOG_FILE} ]; then
-    rm -fv ${JENKINS_LOG_FILE} || echo "Problem removing existing log file."
+    rm -fv ${JENKINS_LOG_FILE} || echo "Problem removing existing log file (${JENKINS_LOG_FILE})."
 fi
 
 echo "${ME}: Retrieving logs from url: ${LOG_URL}"
@@ -35,6 +36,33 @@ while read -r line; do
 done < ${JENKINS_LOG_FILE}
 
 echo " "
-echo " "
-echo " "
 sleep 5
+
+if [ -f ${JENKINS_SERVER_LOG_FILE} ]; then
+    rm -fv ${JENKINS_SERVER_LOG_FILE} || echo "Problem removing existing log file (${JENKINS_SERVER_LOG_FILE})."
+fi
+
+JENKINS_SERVER_PROTOCOL="$(echo \"${LOG_URL}\" | cut -d "/" -f 1)"
+JENKINS_SERVER_HOSTNAME="$(echo \"${LOG_URL}\" | cut -d "/" -f 3)"
+JENKINS_SERVER_LOGS_URL_TAIL="/manage/log/all"
+JENKINS_SERVER_LOGS_URL="${JENKINS_SERVER_PROTOCOL}//${JENKINS_SERVER_HOSTNAME}${JENKINS_SERVER_LOGS_URL_TAIL}"
+
+echo "Jenkins server log url: ${JENKINS_SERVER_LOGS_URL}"
+curl --insecure -sSL --header "Authorization: Bearer ${TOKEN}" ${JENKINS_SERVER_LOGS_URL} > ${JENKINS_SERVER_LOG_FILE} || \
+    echo "${ME}: Error retrieving jenkins server logs with curl, needed to eval problem in failed job ( ${BUILD_NAME} ). "
+
+echo " "
+echo " "
+
+echo "** JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
+echo " "
+while read -r line; do
+    echo "JNK_LOGS: $line ";
+done < ${JENKINS_SERVER_LOG_FILE}
+
+echo " "
+echo "ENDS JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
+echo " "
+echo " "
+echo " "
+sleep 10

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -15,6 +15,7 @@ BUILD_NAME=$2
 BUILD_SEEMS_TO_BE_COMPLETE=${3:-"false"}
 echo "${ME}: Project: ${PROJECT} BuildName: ${BUILD_NAME} BuildSeemsToBeComplete: ${BUILD_SEEMS_TO_BE_COMPLETE} "
 echo " "
+
 LOG_URL=$(oc -n ${PROJECT} get build ${BUILD_NAME} -o jsonpath='{.metadata.annotations.openshift\.io/jenkins-log-url}')
 echo " "
 echo "${ME}: Jenkins log url: ${LOG_URL}"

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -75,11 +75,18 @@ echo " "
 echo " "
 sleep 10
 
+BAD_SERVER_LOGS="false"
+if grep -q 'Still waiting to schedule task' ${JENKINS_LOG_FILE} ; then
+    if grep -q 'HTTP ERROR' ${JENKINS_SERVER_LOG_FILE} ; then
+        BAD_SERVER_LOGS="true"
+    fi
+fi
+
 echo " "
 echo "NO_JOB_LOGS=${NO_JOB_LOGS}"
 echo "NO_SERVER_LOGS=${NO_SERVER_LOGS}"
 echo " "
-if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${NO_SERVER_LOGS}" ]; then
+if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${NO_SERVER_LOGS}" ] || [ "true" == "${BAD_SERVER_LOGS}" ]; then
     echo " "
     echo "A problem was found while retrieving Jenkins job/server logs."
     echo "Since we might need to enter the box and see what went wrong, this pipeline will wait for manual intervention. "

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -4,23 +4,30 @@ set -o pipefail
 
 JENKINS_LOG_FILE="jenkins-downloaded-log.txt"
 JENKINS_SERVER_LOG_FILE="jenkins-server-log.txt"
-WAIT_FOR_MANUAL_INTERVENTION="false"
+OC_ERROR="false"
+LOG_URL="http://localhost"
+TOKEN="none"
 
 echo " "
 echo " "
 echo " "
 PROJECT=$1
 BUILD_NAME=$2
-BUILD_SEEMS_TO_BE_COMPLETE=${3:-"false"}
 ME="$(basename $0)[${BUILD_NAME}]"
-echo "${ME}: Project: ${PROJECT} BuildName: ${BUILD_NAME} BuildSeemsToBeComplete: ${BUILD_SEEMS_TO_BE_COMPLETE} "
+echo "${ME}: Project: ${PROJECT} BuildName: ${BUILD_NAME} "
 echo " "
 
-LOG_URL=$(oc -n ${PROJECT} get build ${BUILD_NAME} -o jsonpath='{.metadata.annotations.openshift\.io/jenkins-log-url}')
+LOG_URL=$(oc -n ${PROJECT} get build ${BUILD_NAME} -o jsonpath='{.metadata.annotations.openshift\.io/jenkins-log-url}' || echo "OC_ERROR" )
+
 echo " "
 echo "${ME}: Jenkins log url: ${LOG_URL}"
 echo " "
-TOKEN=$(oc -n ${PROJECT} get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc -n ${PROJECT} get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | head -n 1 | base64 -d -)
+if [ "OC_ERROR" == "${LOG_URL}" ]; then
+    OC_ERROR="true"
+    TOKEN="OC_ERROR"
+else
+    TOKEN=$(oc -n ${PROJECT} get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc -n ${PROJECT} get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | head -n 1 | base64 -d -)
+fi
 
 if [ -f ${JENKINS_LOG_FILE} ]; then
     rm -fv ${JENKINS_LOG_FILE} || echo "Problem removing existing log file (${JENKINS_LOG_FILE})."
@@ -56,70 +63,51 @@ fi
 # oc login -u developer -p anypwd
 # TOKEN=$(oc -n ${PROJECT} get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc -n ${PROJECT} get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | head -n 1 | base64 -d -)
 
-JENKINS_SERVER_PROTOCOL="$(echo ${LOG_URL} | cut -d "/" -f 1)"
-JENKINS_SERVER_HOSTNAME="$(echo ${LOG_URL} | cut -d "/" -f 3)"
-JENKINS_SERVER_LOGS_URL_TAIL="/manage/log/all"
-JENKINS_SERVER_LOGS_URL="${JENKINS_SERVER_PROTOCOL}//${JENKINS_SERVER_HOSTNAME}${JENKINS_SERVER_LOGS_URL_TAIL}"
+# JENKINS_SERVER_PROTOCOL="$(echo ${LOG_URL} | cut -d "/" -f 1)"
+# JENKINS_SERVER_HOSTNAME="$(echo ${LOG_URL} | cut -d "/" -f 3)"
+# JENKINS_SERVER_LOGS_URL_TAIL="/manage/log/all"
+# JENKINS_SERVER_LOGS_URL="${JENKINS_SERVER_PROTOCOL}//${JENKINS_SERVER_HOSTNAME}${JENKINS_SERVER_LOGS_URL_TAIL}"
 
-echo "${ME}: WARN: The following functionality is not working well yet... :("
-echo "${ME}: Jenkins server log url: ${JENKINS_SERVER_LOGS_URL}"
-curl --insecure -sSL --header "Authorization: Bearer ${TOKEN}" ${JENKINS_SERVER_LOGS_URL} > ${JENKINS_SERVER_LOG_FILE} || \
-    echo "${ME}: Error retrieving jenkins server logs with curl, needed to eval problem in failed job ( ${BUILD_NAME} ). "
+# echo "${ME}: WARN: The following functionality is not working well yet... :("
+# echo "${ME}: Jenkins server log url: ${JENKINS_SERVER_LOGS_URL}"
+# curl --insecure -sSL --header "Authorization: Bearer ${TOKEN}" ${JENKINS_SERVER_LOGS_URL} > ${JENKINS_SERVER_LOG_FILE} || \
+#     echo "${ME}: Error retrieving jenkins server logs with curl, needed to eval problem in failed job ( ${BUILD_NAME} ). "
 
-echo " "
-echo " "
+# echo " "
+# echo " "
 
-echo "${ME}: ** JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
-echo " "
-NO_SERVER_LOGS="true"
-while read -r line; do
-    if [ ! -z "$line" ] && [ "" != "${line}" ]; then
-        NO_SERVER_LOGS="false"
-    fi
-    echo "JNK_LOGS: $line ";
-done < ${JENKINS_SERVER_LOG_FILE}
+# echo "${ME}: ** JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
+# echo " "
+# NO_SERVER_LOGS="true"
+# while read -r line; do
+#    if [ ! -z "$line" ] && [ "" != "${line}" ]; then
+#        NO_SERVER_LOGS="false"
+#    fi
+#    echo "JNK_LOGS: $line ";
+# done < ${JENKINS_SERVER_LOG_FILE}
 
-echo " "
-echo "${ME}: ENDS JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
-echo " "
-echo " "
-echo " "
-sleep 10
+# echo " "
+# echo "${ME}: ENDS JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
+# echo " "
+# echo " "
+# echo " "
+# sleep 10
 
 BAD_SERVER_LOGS="false"
 if grep -q 'Still waiting to schedule task' ${JENKINS_LOG_FILE} ; then
-    if grep -q 'HTTP ERROR' ${JENKINS_SERVER_LOG_FILE} ; then
+#    if grep -q 'HTTP ERROR' ${JENKINS_SERVER_LOG_FILE} ; then
         BAD_SERVER_LOGS="true"
-    fi
+#    fi
 fi
 
 echo " "
 echo "${ME}: NO_JOB_LOGS=${NO_JOB_LOGS}"
-echo "${ME}: NO_SERVER_LOGS=${NO_SERVER_LOGS}"
+# echo "${ME}: NO_SERVER_LOGS=${NO_SERVER_LOGS}"
 echo "${ME}: BAD_SERVER_LOGS=${BAD_SERVER_LOGS}"
 echo " "
 if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${BAD_SERVER_LOGS}" ]; then
-    echo " "
-    echo "${ME}: A problem was found while retrieving Jenkins job/server logs."
-    echo "${ME}: Since we might need to enter the box and see what went wrong, "
-    echo "${ME}: this pipeline will wait for manual intervention. "
-    echo "${ME}: If you just want to continue, kill the sleep process."
-    echo "${ME}: Enjoy..."
-    WAIT_FOR_MANUAL_INTERVENTION="true"
+    echo "${ME}: ERROR: Logs retrieved are not good enough."
+    exit 1
 fi
 
-echo "${BUILD_SEEMS_TO_BE_COMPLETE}" | grep -qi "true" || \
-    echo "Build is not complete: ${BUILD_SEEMS_TO_BE_COMPLETE}"
-echo "${BUILD_SEEMS_TO_BE_COMPLETE}" | grep -qi "true" || \
-    WAIT_FOR_MANUAL_INTERVENTION="true"
-
-if [ "true" == "${WAIT_FOR_MANUAL_INTERVENTION}" ]; then
-    echo " "
-    echo "${ME}: WAITING FOR MANUAL INTERVENTION ( WAIT_FOR_MANUAL_INTERVENTION = true ) "
-    echo "${ME}: sleep 72000 ( 20h )"
-    echo " "
-    echo " "
-    sleep 72000 || echo "${ME}: Sleep returned value != 0. Maybe aborted ?? "
-    echo " "
-    echo " "
-fi
+exit 0

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -5,13 +5,16 @@ set -o pipefail
 ME="$(basename $0)"
 JENKINS_LOG_FILE="jenkins-downloaded-log.txt"
 JENKINS_SERVER_LOG_FILE="jenkins-server-log.txt"
-WAIT_FOR_MANUAL_INTERVENTION="true"
+WAIT_FOR_MANUAL_INTERVENTION="false"
 
 echo " "
 echo " "
 echo " "
 PROJECT=$1
 BUILD_NAME=$2
+BUILD_SEEMS_TO_BE_COMPLETE=${3:-"false"}
+echo "${ME}: Project: ${PROJECT} BuildName: ${BUILD_NAME} BuildSeemsToBeComplete: ${BUILD_SEEMS_TO_BE_COMPLETE} "
+echo " "
 LOG_URL=$(oc -n ${PROJECT} get build ${BUILD_NAME} -o jsonpath='{.metadata.annotations.openshift\.io/jenkins-log-url}')
 echo " "
 echo "${ME}: Jenkins log url: ${LOG_URL}"
@@ -91,7 +94,8 @@ echo " "
 echo "NO_JOB_LOGS=${NO_JOB_LOGS}"
 echo "NO_SERVER_LOGS=${NO_SERVER_LOGS}"
 echo " "
-if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${NO_SERVER_LOGS}" ] || [ "true" == "${BAD_SERVER_LOGS}" ]; then
+if [ "true" == "${NO_JOB_LOGS}" ] || [ "true" == "${NO_SERVER_LOGS}" ] ||
+    [ "true" == "${BAD_SERVER_LOGS}" ] || [ "true" != "${BUILD_SEEMS_TO_BE_COMPLETE}" ]; then
     echo " "
     echo "A problem was found while retrieving Jenkins job/server logs."
     echo "Since we might need to enter the box and see what went wrong, this pipeline will wait for manual intervention. "

--- a/tests/scripts/print-jenkins-log.sh
+++ b/tests/scripts/print-jenkins-log.sh
@@ -59,40 +59,6 @@ if [ -f ${JENKINS_SERVER_LOG_FILE} ]; then
         echo "${ME}: Problem removing existing log file (${JENKINS_SERVER_LOG_FILE})."
 fi
 
-# Does not work :-(
-# oc login -u developer -p anypwd
-# TOKEN=$(oc -n ${PROJECT} get sa/jenkins --template='{{range .secrets}}{{ .name }} {{end}}' | xargs -n 1 oc -n ${PROJECT} get secret --template='{{ if .data.token }}{{ .data.token }}{{end}}' | head -n 1 | base64 -d -)
-
-# JENKINS_SERVER_PROTOCOL="$(echo ${LOG_URL} | cut -d "/" -f 1)"
-# JENKINS_SERVER_HOSTNAME="$(echo ${LOG_URL} | cut -d "/" -f 3)"
-# JENKINS_SERVER_LOGS_URL_TAIL="/manage/log/all"
-# JENKINS_SERVER_LOGS_URL="${JENKINS_SERVER_PROTOCOL}//${JENKINS_SERVER_HOSTNAME}${JENKINS_SERVER_LOGS_URL_TAIL}"
-
-# echo "${ME}: WARN: The following functionality is not working well yet... :("
-# echo "${ME}: Jenkins server log url: ${JENKINS_SERVER_LOGS_URL}"
-# curl --insecure -sSL --header "Authorization: Bearer ${TOKEN}" ${JENKINS_SERVER_LOGS_URL} > ${JENKINS_SERVER_LOG_FILE} || \
-#     echo "${ME}: Error retrieving jenkins server logs with curl, needed to eval problem in failed job ( ${BUILD_NAME} ). "
-
-# echo " "
-# echo " "
-
-# echo "${ME}: ** JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
-# echo " "
-# NO_SERVER_LOGS="true"
-# while read -r line; do
-#    if [ ! -z "$line" ] && [ "" != "${line}" ]; then
-#        NO_SERVER_LOGS="false"
-#    fi
-#    echo "JNK_LOGS: $line ";
-# done < ${JENKINS_SERVER_LOG_FILE}
-
-# echo " "
-# echo "${ME}: ENDS JENKINS LOGS (JNK_LOGS) AFTER PROBLEM BUILDING JOB ${BUILD_NAME}: "
-# echo " "
-# echo " "
-# echo " "
-# sleep 10
-
 BAD_SERVER_LOGS="false"
 if grep -q 'Still waiting to schedule task' ${JENKINS_LOG_FILE} ; then
     if ! grep -q 'Finished: SUCCESS' ${JENKINS_LOG_FILE} ; then

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -24,8 +24,8 @@ fi
 
 sleep 5
 echo " "
-echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 140m github.com/opendevstack/ods-core/tests/smoketest "
-go test -v -count=1 -timeout 140m github.com/opendevstack/ods-core/tests/smoketest | tee test-smoketest-results.txt 2>&1
+echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/smoketest "
+go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/smoketest | tee test-smoketest-results.txt 2>&1
 exit_code=$?
 echo "${THIS_SCRIPT}: return value: ${exit_code}"
 

--- a/tests/smoke-test.sh
+++ b/tests/smoke-test.sh
@@ -24,8 +24,8 @@ fi
 
 sleep 5
 echo " "
-echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/smoketest "
-go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/smoketest | tee test-smoketest-results.txt 2>&1
+echo "${THIS_SCRIPT}: go test -v -count=1 -timeout 30h github.com/opendevstack/ods-core/tests/smoketest "
+go test -v -count=1 -timeout 30h github.com/opendevstack/ods-core/tests/smoketest | tee test-smoketest-results.txt 2>&1
 exit_code=$?
 echo "${THIS_SCRIPT}: return value: ${exit_code}"
 

--- a/tests/smoketest/provision-api_test.go
+++ b/tests/smoketest/provision-api_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/opendevstack/ods-core/tests/utils"
 	projectClientV1 "github.com/openshift/client-go/project/clientset/versioned/typed/project/v1"
@@ -58,6 +59,8 @@ func TestVerifyOdsProjectProvisionThruProvisionApi(t *testing.T) {
 		values["ODS_NAMESPACE"], exJob.FullBuildName,
 	)
 	if err != nil {
+	    time.Sleep(10 * time.Second)
+	    fmt.Printf("Error retrieving jenkins build stages for build: %s\n", projectName)
 		t.Fatal(err)
 	}
 	fmt.Printf("Jenkins stages: \n'%s'\n", stages)

--- a/tests/smoketest/provision-api_test.go
+++ b/tests/smoketest/provision-api_test.go
@@ -59,8 +59,8 @@ func TestVerifyOdsProjectProvisionThruProvisionApi(t *testing.T) {
 		values["ODS_NAMESPACE"], exJob.FullBuildName,
 	)
 	if err != nil {
-	    time.Sleep(10 * time.Second)
-	    fmt.Printf("Error retrieving jenkins build stages for build: %s\n", projectName)
+		time.Sleep(10 * time.Second)
+		fmt.Printf("Error retrieving jenkins build stages for build: %s\n", projectName)
 		t.Fatal(err)
 	}
 	fmt.Printf("Jenkins stages: \n'%s'\n", stages)

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -93,6 +93,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 
 	fmt.Printf("Getting stages for build: %s in project: %s\n",
 		buildName, jenkinsNamespace)
+	fmt.Printf("To get more info, use print-jenkins-log.sh %s %s \n", jenkinsNamespace, buildName)
 
 	config, err := GetOCClient()
 	if err != nil {
@@ -125,8 +126,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 				}
 			}
 		} else {
-			fmt.Printf("Waiting (%d/%d) for build to complete: %s. Current status: %s\n", count, max, buildName, build.Status.Phase)
-			fmt.Printf("To get more info, use print-jenkins-log.sh %s %s \n", jenkinsNamespace, buildName)
+			fmt.Printf("Waiting for build of %s to complete (%d/%d). Current status: %s\n", buildName, count, max, build.Status.Phase)
 		}
 		count++
 	}

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -174,7 +174,18 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 	}
 
 	// print in any case, otherwise when err != nil no logs are shown
-	fmt.Printf("buildlog: %s\n%s", buildName, stdout)
+	fmt.Printf("[Jenkins buildlog]: buildName: %s\n%s", buildName, stdout)
+
+	problematicSubString := "Still waiting to schedule task"
+	exceptionProblematicSubString := "Finished: SUCCESS"
+	if len(stdout) > 0 && (strings.Contains(stdout, problematicSubString)) {
+		if !strings.Contains(stdout, exceptionProblematicSubString) {
+			fmt.Printf("Jenkins log contains problematic substring ( %s ) and "+
+				" it does not contain exception case string: ( %s ) \n", problematicSubString,
+				exceptionProblematicSubString)
+			errorGettingInfoNeeded = "true"
+		}
+	}
 
 	// get (executed) jenkins stages from run - the caller can compare against the golden record
 	stdout, stderr, err = RunScriptFromBaseDir(
@@ -187,6 +198,14 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 	if err != nil {
 		fmt.Printf("ERROR: Problem getting jenkins stages for: %s\rError: %s, %s, %s",
 			buildName, err, stdout, stderr)
+		errorGettingInfoNeeded = "true"
+	}
+
+	// print in any case, otherwise when err != nil no logs are shown
+	fmt.Printf("[get oc build status]: buildName: %s\n%s", buildName, stdout)
+
+	problematicSubString2 := "ERROR: Could not get oc build status named"
+	if len(stdout) > 0 && (strings.Contains(stdout, problematicSubString2)) {
 		errorGettingInfoNeeded = "true"
 	}
 

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -131,11 +131,11 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		count++
 	}
 
-    buildSeemsToBeComplete := true
+	buildSeemsToBeComplete := true
 	// in case the the build was sort of never really started - get the jenkins pod log, maybe there
 	// is a plugin / sync problem?
-	if (build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning) {
-	    buildSeemsToBeComplete := false
+	if build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning {
+		buildSeemsToBeComplete := false
 		// get the jenkins pod log
 		stdoutJPod, stderrJPod, errJPod := RunScriptFromBaseDir(
 			"tests/scripts/print-jenkins-pod-log.sh",
@@ -155,7 +155,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		[]string{
 			jenkinsNamespace,
 			buildName,
-			buildSeemsToBeComplete
+			buildSeemsToBeComplete,
 		}, []string{})
 
 	if err != nil {

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -131,9 +131,11 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		count++
 	}
 
+    buildSeemsToBeComplete := true
 	// in case the the build was sort of never really started - get the jenkins pod log, maybe there
 	// is a plugin / sync problem?
-	if build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending {
+	if (build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning) {
+	    buildSeemsToBeComplete := false
 		// get the jenkins pod log
 		stdoutJPod, stderrJPod, errJPod := RunScriptFromBaseDir(
 			"tests/scripts/print-jenkins-pod-log.sh",
@@ -153,6 +155,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		[]string{
 			jenkinsNamespace,
 			buildName,
+			buildSeemsToBeComplete
 		}, []string{})
 
 	if err != nil {

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -149,13 +149,18 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		}
 	}
 
+	buildSeemsToBeCompleteStr := "false"
+	if buildSeemsToBeComplete {
+		buildSeemsToBeCompleteStr := "true"
+	}
+
 	// get the jenkins run build log
 	stdout, stderr, err := RunScriptFromBaseDir(
 		"tests/scripts/print-jenkins-log.sh",
 		[]string{
 			jenkinsNamespace,
 			buildName,
-			buildSeemsToBeComplete,
+			buildSeemsToBeCompleteStr,
 		}, []string{})
 
 	if err != nil {

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -149,7 +149,9 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		}
 	}
 
-	fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeComplete)
+	if buildSeemsToBeComplete == "true" || buildSeemsToBeComplete != "true" {
+		fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeComplete)
+	}
 
 	// get the jenkins run build log
 	stdout, stderr, err := RunScriptFromBaseDir(

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -131,11 +131,11 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		count++
 	}
 
-	buildSeemsToBeComplete := true
+	buildSeemsToBeComplete := "true"
 	// in case the the build was sort of never really started - get the jenkins pod log, maybe there
 	// is a plugin / sync problem?
 	if build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning {
-		buildSeemsToBeComplete := false
+		buildSeemsToBeComplete := "false"
 		// get the jenkins pod log
 		stdoutJPod, stderrJPod, errJPod := RunScriptFromBaseDir(
 			"tests/scripts/print-jenkins-pod-log.sh",
@@ -149,11 +149,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		}
 	}
 
-	buildSeemsToBeCompleteStr := "false"
-	if buildSeemsToBeComplete {
-		buildSeemsToBeCompleteStr := "true"
-	}
-	fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeCompleteStr)
+	fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeComplete)
 
 	// get the jenkins run build log
 	stdout, stderr, err := RunScriptFromBaseDir(
@@ -161,7 +157,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		[]string{
 			jenkinsNamespace,
 			buildName,
-			buildSeemsToBeCompleteStr,
+			buildSeemsToBeComplete,
 		}, []string{})
 
 	if err != nil {

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -153,6 +153,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 	if buildSeemsToBeComplete {
 		buildSeemsToBeCompleteStr := "true"
 	}
+	fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeCompleteStr)
 
 	// get the jenkins run build log
 	stdout, stderr, err := RunScriptFromBaseDir(

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -131,9 +131,11 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		count++
 	}
 
+	buildSeemsToBeComplete := "true"
 	// in case the the build was sort of never really started - get the jenkins pod log, maybe there
 	// is a plugin / sync problem?
 	if build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning {
+		buildSeemsToBeComplete = "false"
 		// get the jenkins pod log
 		stdoutJPod, stderrJPod, errJPod := RunScriptFromBaseDir(
 			"tests/scripts/print-jenkins-pod-log.sh",
@@ -147,13 +149,15 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		}
 	}
 
+    fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeComplete)
+
 	// get the jenkins run build log
 	stdout, stderr, err := RunScriptFromBaseDir(
 		"tests/scripts/print-jenkins-log.sh",
 		[]string{
 			jenkinsNamespace,
 			buildName,
-			isBuildCompleteInPrinciple(build),
+			buildSeemsToBeComplete,
 		}, []string{})
 
 	if err != nil {
@@ -190,16 +194,6 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 	}
 
 	return stdout, nil
-}
-
-func isBuildCompleteInPrinciple(build) string {
-	if build.Status.Phase == v1.BuildPhaseNew || build.Status.Phase == v1.BuildPhasePending || build.Status.Phase == v1.BuildPhaseRunning {
-		fmt.Printf("Build seems to be complete ? : false \n")
-		return false
-	}
-
-	fmt.Printf("Build seems to be complete ? : true \n")
-	return true
 }
 
 func VerifyJenkinsRunAttachments(projectName string, buildName string, artifactsToVerify []string) error {

--- a/tests/utils/jenkins.go
+++ b/tests/utils/jenkins.go
@@ -149,7 +149,7 @@ func RetrieveJenkinsBuildStagesForBuild(jenkinsNamespace string, buildName strin
 		}
 	}
 
-    fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeComplete)
+	fmt.Printf("Build seems to be complete ? : %s \n", buildSeemsToBeComplete)
 
 	// get the jenkins run build log
 	stdout, stderr, err := RunScriptFromBaseDir(

--- a/tests/utils/provisioning.go
+++ b/tests/utils/provisioning.go
@@ -70,6 +70,7 @@ func (api *ProvisionAPI) CreateProject() ([]byte, error) {
 		return nil, fmt.Errorf("Could not read response file?!, %s", err)
 	}
 	fmt.Printf("Provision results: %s\n", string(log))
+	fmt.Printf("-----\n")
 	return log, nil
 }
 
@@ -130,5 +131,6 @@ func (api *ProvisionAPI) CreateComponent() ([]byte, error) {
 		return nil, fmt.Errorf("Could not read response file?!, %w", err)
 	}
 	fmt.Printf("Provision results: %s\n", string(log))
+	fmt.Printf("-----\n")
 	return log, nil
 }

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -15,8 +15,8 @@ fi
 if [ -f test-verify-results.txt ]; then
     rm test-verify-results.txt
 fi
-echo "go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/ods-verify"
-go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/ods-verify | tee test-verify-results.txt 2>&1
+echo "go test -v -count=1 -timeout 30h github.com/opendevstack/ods-core/tests/ods-verify"
+go test -v -count=1 -timeout 30h github.com/opendevstack/ods-core/tests/ods-verify | tee test-verify-results.txt 2>&1
 exitcode=$?
 if [ -f test-verify-results.txt ]; then
     set -e

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -15,7 +15,8 @@ fi
 if [ -f test-verify-results.txt ]; then
     rm test-verify-results.txt
 fi
-go test -v -count=1 -timeout 60m github.com/opendevstack/ods-core/tests/ods-verify | tee test-verify-results.txt 2>&1
+echo "go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/ods-verify"
+go test -v -count=1 -timeout 10h github.com/opendevstack/ods-core/tests/ods-verify | tee test-verify-results.txt 2>&1
 exitcode=$?
 if [ -f test-verify-results.txt ]; then
     set -e


### PR DESCRIPTION
Removes existing differences between jenkins agent base image in Centos 7 and UBI 8 which, for example, cause different behaviour when running quickstaters.

- [x] jre not found by Jenkins agents when launched. In Centos7 images, install jre 11 and uninstall deprecated jre 8. 
- [x] default value for JAVA_TOOL_OPTIONS has UseCGroupMemoryLimitForHeap, which is deprecated in jre 11 and cannot be used. In UBI 8 base images this default value is not set. Remove it from Centos 7 base img for agents.
- [x] default value for JAVA_GC_OPTS contains `-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90`. Some of the options are incompatible with the options proposed in https://github.com/opendevstack/ods-core/pull/1161 (`-server -XX:NativeMemoryTracking=summary -XX:MaxRAMPercentage=90 -XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:MaxMetaspaceSize=1g -XX:MetaspaceSize=256M -XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:G1SummarizeRSetStatsPeriod=1
-Xmx4g`). Although we do not use all that options for agents pods, we cannot afford setting contradictory options. 
- [x] smoke tests fail during ods box creation. Reason: the default parameters for JAVA_TOOL_OPTIONS and JAVA_GC_OPTS 
- [x] Not set default speed/durability setting to SURVIVABLE_NONATOMIC (as requested in https://github.com/opendevstack/ods-core/pull/1161 ). Seems to be the script is missing some imports.
- [x] The [Config.NameToCertificate](https://go.dev/pkg/crypto/tls/#Config.NameToCertificate) field, which only supports associating a single certificate with a give name, is now deprecated and should be left as nil. https://go.dev/pkg/crypto/tls/
- [x] When an error occurs running a quickstarter or smoke test and we cannot retrieve the logs, wait for manual intervention (at most 24h). Some issues need much more information than the one we retrieve in logs and it is faster allowing to connect to the boxes at that point in the execution flow.