### PR TITLE
Update Containers Probes in Jenkins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update Containers Probes in Jenkins ([#1191](https://github.com/opendevstack/ods-core/issues/1191))
+
 ## [4.1.1] - 2022-11-24
 
 - Fix CI/CD problems in Jenkins pipelines ([#1177](https://github.com/opendevstack/ods-core/pull/1177))

--- a/jenkins/ocp-config/deploy/jenkins-master.yml
+++ b/jenkins/ocp-config/deploy/jenkins-master.yml
@@ -144,7 +144,7 @@ objects:
     strategy:
       activeDeadlineSeconds: 21600
       recreateParams:
-        timeoutSeconds: 600
+        timeoutSeconds: 1200
       resources: {}
       type: Recreate
     template:
@@ -201,27 +201,34 @@ objects:
               value: '${BITBUCKET_URL}'
           image: '${DOCKER_REGISTRY}/${ODS_NAMESPACE}/jenkins-master:${ODS_IMAGE_TAG}'
           imagePullPolicy: Always
-          livenessProbe:
-            failureThreshold: 30
+          startupProbe:
             httpGet:
               path: /login
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 120
+            timeoutSeconds: 3
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /login
+              port: 8080
+              scheme: HTTP
+            timeoutSeconds: 3
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            failureThreshold: 30
           name: jenkins
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /login
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 3
+            timeoutSeconds: 3
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 3
+            failureThreshold: 30
           resources:
             limits:
               cpu: ${JENKINS_CPU_LIMIT}


### PR DESCRIPTION
fix for #1191 

This is needed as we have seen in our biggest cluster issues with Jenkins and its porbes due to the amount of instances

@metmajer @michaelsauter 