### PR TITLE
Nexus maintance - update to 3.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Maintenance, update nexus to version 3.45.1 ([#1201](https://github.com/opendevstack/ods-core/pull/1201))
+
 ## [4.1.1] - 2022-11-24
 
 - Fix CI/CD problems in Jenkins pipelines ([#1177](https://github.com/opendevstack/ods-core/pull/1177))

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -44,7 +44,7 @@ ODS_BITBUCKET_PROJECT=opendevstack
 
 # Nexus base image
 # See https://hub.docker.com/r/sonatype/nexus3/tags.
-NEXUS_FROM_IMAGE=sonatype/nexus3:3.40.1
+NEXUS_FROM_IMAGE=sonatype/nexus3:3.45.1
 
 # Nexus host without protocol.
 # The domain should be equal to OPENSHIFT_APPS_BASEDOMAIN (see below).

--- a/nexus/configure.sh
+++ b/nexus/configure.sh
@@ -188,10 +188,8 @@ function changeScriptSetting {
     fi
 }
 
-# In the local context changeScriptSetting works directly after docker run
-if [ -z "${LOCAL_CONTAINER_ID}" ]; then
-    waitForReady
-fi
+waitForReady
+
 changeScriptSetting "true"
 
 waitForReady


### PR DESCRIPTION
Update Nexus version to latest version (3.45.1)

- [x] Update an existing Nexus instance successfully
- [x] Create a new Nexus instance and run "make configure-nexus" successfully