### PR TITLE
SonarQube Rust language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Memory malloc arena fix for Jenkins ([#1217](https://github.com/opendevstack/ods-core/pull/1217))
 - Added webhook proxy feature to check for Jenkins availability ([#1221](https://github.com/opendevstack/ods-core/issues/1221))
+- Add SonarQube Rust plugin ([#1220](https://github.com/opendevstack/ods-core/issues/1220))
 
 
 ## [4.2.0] - 2023-02-21
@@ -40,7 +41,7 @@
 - Add plugins necessary to upgrade to 4.9 base image in the list of managed plugins ([#1121](https://github.com/opendevstack/ods-core/pull/1121))
 - Upgraded atlassian suite to 8.20.6 and added functionality to upgrade without reinstalling all the box.
 - Upgrades needed by Github and Jenkins pipelines to work again. Includes some pipeline modifications to detect errors early.
-- Upgrades atlassian suite ([#1138](https://github.com/opendevstack/ods-core/issues/1138)) 
+- Upgrades atlassian suite ([#1138](https://github.com/opendevstack/ods-core/issues/1138))
 - deploy.sh checks that services started are up and ensures resolv.conf is updated if service ip changes ([#1152](https://github.com/opendevstack/ods-core/pull/1152))
 - Remove Jcenter from Nexus ([#804](https://github.com/opendevstack/ods-quickstarters/issues/804))
 - Needed changes to run CI again, ported from task/upgrade-atlassian-stack. Run quickstarters in parallel, typos.

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -58,6 +58,8 @@ ADD https://github.com/vaulttec/sonar-auth-oidc/releases/download/v2.1.1/sonar-a
 # Language plugins not bundled
 ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.7/sonar-groovy-plugin-1.7.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/Merck/sonar-r-plugin/releases/download/0.2.1/sonar-r-plugin-0.2.1.jar /opt/configuration/sonarqube/plugins/
+# When running SonarQube 9.9LTS this plugin can be upgraded to 0.2.x
+ADD https://github.com/elegoff/sonar-rust/releases/download/v0.1.0/community-rust-plugin-0.1.0.jar /opt/configuration/sonarqube/plugins/
 
 RUN chown -R :0 /opt/configuration/sonarqube/plugins; \
     chmod -R g=u /opt/configuration/sonarqube/plugins; \

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -85,7 +85,7 @@ if ! $VERIFY_ONLY; then
             echo -n "Sonar edition provided ${SONAR_EDITION} is not valid"; exit 1;;
 
     esac
-        
+
         HOST_PORT="9000"
         CONTAINER_IMAGE="sqtest"
 
@@ -215,8 +215,9 @@ case $SONAR_EDITION in
     community | developer | enterprise | datacenter)
         expectedPlugins=( "crowd:2.1.3"
                 "authoidc:2.1.1"
-                "groovy:1.7" 
-                "r:0.2.1" )
+                "groovy:1.7"
+                "r:0.2.1"
+                "communityrust:0.1.0" )
         ;;
 
     *)


### PR DESCRIPTION
closes #1220

once #1211 is done then we can upgrade the SonarQube Rust plugin to 0.2.0 (or above)