### PR TITLE
do not execute codeql on push if branch is dependabot/**

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
   schedule:
     - cron: '0 15 * * 3'


### PR DESCRIPTION
codeql should not be executed on push (for PRs) initiated by dependabot