### PR TITLE
fix allowed change ref types environment read

### DIFF
--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -204,7 +204,7 @@ func main() {
 
 	var allowedChangeRefTypes []string
 	envAllowedChangeRefTypes := strings.ToLower(os.Getenv(allowedChangeRefTypesEnvVar))
-	if len(allowedChangeRefTypes) == 0 {
+	if len(envAllowedChangeRefTypes) == 0 {
 		allowedChangeRefTypes = strings.Split(allowedChangeRefTypesDefault, ",")
 		log.Println(
 			"INFO:",


### PR DESCRIPTION
change the name of the variable in the if clause for the one that contains the env values. Follow the same approach that other Env Variables