### PR TITLE
create and set permissions for the folder used in Aqua scanner execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Aqua scanner and Helm deployment conflict fix for jenkins agent ([#1067](https://github.com/opendevstack/ods-jenkins-shared-library/issues/1067))
+
 ## [4.3.0] - 2023-07-03
 
 ### Added

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -140,5 +140,6 @@ RUN yum install -y skopeo \
 # Fix permissions.
 RUN mkdir -p /home/jenkins/.config && chmod -R g+w /home/jenkins/.config \
     && mkdir -p /home/jenkins/.cache && chmod -R g+w /home/jenkins/.cache \
-    && mkdir -p /home/jenkins/.sonar && chmod -R g+w /home/jenkins/.sonar
+    && mkdir -p /home/jenkins/.sonar && chmod -R g+w /home/jenkins/.sonar \
+    && mkdir -p /tmp/aqua && chmod -R g+w /tmp/aqua
 


### PR DESCRIPTION
Fix https://github.com/opendevstack/ods-jenkins-shared-library/issues/1067 in the jenkins agent

related to https://github.com/opendevstack/ods-jenkins-shared-library/pull/1068