### PR TITLE
Update Nexus to version 3.68.1-java11 to fix CVE-2024-4956

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Update SonarQube to 9.9.5 and configure resources for Nexus and Sonarqube in ods-configuration ([#1283](https://github.com/opendevstack/ods-core/pull/1283))
+- Update Nexus to 3.68.1-java11 to address a critical vulnerability ([#1286](https://github.com/opendevstack/ods-core/pull/1286))
 
 ## [4.4.0] - 2024-04-22
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -45,8 +45,8 @@ ODS_BITBUCKET_PROJECT=opendevstack
 # Nexus base image
 # See Dockerhub https://hub.docker.com/r/sonatype/nexus3/tags.
 # Officially supported is:
-# - 3.67.1-java11
-NEXUS_IMAGE_TAG=3.67.1-java11
+# - 3.68.1-java11
+NEXUS_IMAGE_TAG=3.68.1-java11
 
 # Nexus host without protocol.
 # The domain should be equal to OPENSHIFT_APPS_BASEDOMAIN (see below).

--- a/nexus/chart/Chart.yaml
+++ b/nexus/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.67.1-java11"
+appVersion: "3.68.1-java11"


### PR DESCRIPTION
Update Nexus to version 3.68.1-java11 in order to address a critical vulnerability ([CVE-2024-4956](https://support.sonatype.com/hc/en-us/articles/29416509323923-CVE-2024-4956-Nexus-Repository-3-Path-Traversal-2024-05-16?_ga=2.10668854.360314846.1715865970-152591973.1710489196))

![image](https://github.com/opendevstack/ods-core/assets/26645694/7aa43501-53d5-40df-a9c6-cf8aee60d6ad)
