### PR TITLE
Adjust Webhook Proxy resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Update SonarQube to 9.9.6 ([#1292](https://github.com/opendevstack/ods-core/pull/1292))
+- Lower Webhook Proxy resources to match real usage ([#1293](https://github.com/opendevstack/ods-core/pull/1293))
 
 ### Fixed
 

--- a/jenkins/ocp-config/deploy/jenkins-webhook-proxy.yml
+++ b/jenkins/ocp-config/deploy/jenkins-webhook-proxy.yml
@@ -21,13 +21,13 @@ parameters:
 - name: ODS_BITBUCKET_PROJECT
   required: true
 - name: WEBHOOK_PROXY_CPU_REQUEST
-  value: 50m
+  value: 10m
 - name: WEBHOOK_PROXY_CPU_LIMIT
-  value: 200m
+  value: 25m
 - name: WEBHOOK_PROXY_MEMORY_REQUEST
-  value: 128Mi
+  value: 30Mi
 - name: WEBHOOK_PROXY_MEMORY_LIMIT
-  value: 128Mi
+  value: 40Mi
 objects:
 - apiVersion: route.openshift.io/v1
   kind: Route


### PR DESCRIPTION
Adjust Webhook Proxy resources to match the real usage metrics in an effort to optimize Cluster resources.

Modifications:

| | CPU Request | CPU Limit | Mem Request  | Mem Limit |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Before  | 50m  | 200m  | 128Mi  | 128Mi  | 
| After  | 10m  | 25m  | 30Mi  | 40Mi  | 

24-hour metrics from an active project:

![image](https://github.com/opendevstack/ods-core/assets/26645694/70288c6f-ccc8-4e5f-a75e-74ea52e48723)

