### PR TITLE
Update SonarQube to 10.x non LTS

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: ['9.9.4'] # 9.9 = LTS
+        version: ['10.6.0'] # 9.9 = LTS
         edition: ['community', 'developer', 'enterprise']
     steps:
       -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - Webhook Proxy maintenance ([#1298](https://github.com/opendevstack/ods-core/pull/1298))
-
+- Update SonarQube to 10.x non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
 - Jenkins maintenance ([#1299](https://github.com/opendevstack/ods-core/pull/1299)) and update java version in Jenkins ([#1295](https://github.com/opendevstack/ods-core/issues/1295))
 
 ### Fixed

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -134,8 +134,8 @@ SONAR_EDITION=community
 # SonarQube version.
 # See Dockerhub https://hub.docker.com/_/sonarqube/tags
 # Officially supported is:
-# - 9.9 (LTS release)
-SONAR_VERSION=9.9.6
+# - 10.6.0
+SONAR_VERSION=10.6.0
 
 # SonarQube memory and CPU resources
 SONARQUBE_CPU_REQUEST=200m

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -2,9 +2,8 @@ FROM quay.io/openshift/origin-jenkins-agent-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# SONAR_SCANNER_VERSION above 4.8.x require java 17 to run.
-ENV SONAR_SCANNER_VERSION=5.0.1.3006 \
-    CNES_REPORT_VERSION=4.3.0 \
+ENV SONAR_SCANNER_VERSION=6.1.0.4477 \
+    CNES_REPORT_VERSION=5.0.0 \
     TAILOR_VERSION=1.3.4 \
     SOPS_VERSION=3.9.0 \
     HELM_VERSION=3.15.4 \

--- a/sonarqube/chart/Chart.yaml
+++ b/sonarqube/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/sonarqube/chart/Chart.yaml
+++ b/sonarqube/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "9.9.6"
+appVersion: "10.6.0"

--- a/sonarqube/chart/templates/dc-sonar.yaml
+++ b/sonarqube/chart/templates/dc-sonar.yaml
@@ -84,7 +84,10 @@ spec:
             - name: SONAR_SEARCH_JAVAADDITIONALOPTS
               value: '-Dlog4j2.formatMsgNoLookups=true'
             - name: SONARQUBE_JDBC_URL
-              value: 'jdbc:postgresql://{{ .Values.global.appName }}-postgresql:5432/sonarqube'
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.global.appName }}
+                  key: database-jdbc-url
             - name: SONAR_FORCEAUTHENTICATION
               value: 'true'
             - name: SONAR_AUTH_SAML_ENABLED

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG sonarVersion=9.9.4
+ARG sonarVersion=10.6.0
 ARG sonarEdition=community
 
 FROM sonarqube:${sonarVersion}-${sonarEdition}
@@ -23,7 +23,7 @@ RUN mkdir -p /opt/configuration/sonarqube/plugins
 # Language plugins not bundled
 ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.8/sonar-groovy-plugin-1.8.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/Merck/sonar-r-plugin/releases/download/0.2.2/sonar-r-plugin-0.2.2.jar /opt/configuration/sonarqube/plugins/
-ADD https://github.com/elegoff/sonar-rust/releases/download/v0.2.1/community-rust-plugin-0.2.1.jar /opt/configuration/sonarqube/plugins/
+ADD https://github.com/elegoff/sonar-rust/releases/download/v0.2.4/community-rust-plugin-0.2.4.jar /opt/configuration/sonarqube/plugins/
 
 COPY run.sh $SONARQUBE_HOME/bin/
 

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -191,7 +191,7 @@ case $SONAR_EDITION in
     community | developer | enterprise | datacenter)
         expectedPlugins=("groovy:1.8"
                 "r:0.2.2"
-                "communityrust:0.2.1" )
+                "communityrust:0.2.4" )
         ;;
 
     *)

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -6,14 +6,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}
 ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
-SONAR_VERSION=9.9.6
+SONAR_VERSION=10.6.0
 SONAR_EDITION="community"
 
 function usage {
     printf "Test SonarQube setup.\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
-    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '9.9.4' (defaults to %s)\n" "${SONAR_VERSION}"
+    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.6.0' (defaults to %s)\n" "${SONAR_VERSION}"
     printf "\t-e|--sq-edition\t\tSonarQube edition, e.g. 'community' or 'enterprise' (defaults to %s)\n" "${SONAR_EDITION}"
     printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
     printf "\t--verify\t\tSkips setup of local docker container and instead checks existing sonarqube setup based on ods-core.env\n"


### PR DESCRIPTION
Closes #1300 


Test: 
- [x] Deploy SonarQube 10.6
- [x] Sonar scanner and Cnes report binaries updated in Jenkins agent
- [x] Jenkins SonarQube stage successfully executed with the updated agent
- [x] Update from SonarQube 9.9 LTS to SonarQube 10.6
- [x] Run configuration script in a clean SonarQube instance