### PR TITLE
Update Aqua CLi to 2022.4.588

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Webhook Proxy maintenance ([#1298](https://github.com/opendevstack/ods-core/pull/1298))
 - Update SonarQube to 10.x non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
 - Jenkins maintenance ([#1299](https://github.com/opendevstack/ods-core/pull/1299)) and update java version in Jenkins ([#1295](https://github.com/opendevstack/ods-core/issues/1295))
+- Update Aqua CLI version ([#1298](https://github.com/opendevstack/ods-core/pull/1298))
 
 ### Fixed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -250,8 +250,8 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # Releases are published at https://download.aquasec.com/scanner
 # Check Aqua versions backward compatibility at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
 # To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
-# Latest tested version is 2022.4.517
-# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.587/scannercli
+# Latest tested version is 2022.4.588
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.588/scannercli
 JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 # Repository of shared library


### PR DESCRIPTION
Update Aqua CLI in order to support:

- https://github.com/opendevstack/ods-jenkins-shared-library/pull/1147
- https://github.com/opendevstack/ods-jenkins-shared-library/pull/1157
- https://github.com/opendevstack/ods-jenkins-shared-library/pull/1161
