### PR TITLE
Update SonarQube to version 10.7

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: ['10.6.0'] # 9.9 = LTS
+        version: ['10.7.0'] # 9.9 = LTS
         edition: ['community', 'developer', 'enterprise']
     steps:
       -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Changed
 - Webhook Proxy maintenance ([#1298](https://github.com/opendevstack/ods-core/pull/1298))
-- Update SonarQube to 10.x non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
+- Update SonarQube to 10.6 non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
 - Jenkins maintenance ([#1299](https://github.com/opendevstack/ods-core/pull/1299)) and update java version in Jenkins ([#1295](https://github.com/opendevstack/ods-core/issues/1295))
+- Update SonarQube to 10.7 non LTS ([#1298](https://github.com/opendevstack/ods-core/pull/1309))
 
 ### Fixed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -134,8 +134,8 @@ SONAR_EDITION=community
 # SonarQube version.
 # See Dockerhub https://hub.docker.com/_/sonarqube/tags
 # Officially supported is:
-# - 10.6.0
-SONAR_VERSION=10.6.0
+# - 10.7.0
+SONAR_VERSION=10.7.0
 
 # SonarQube memory and CPU resources
 SONARQUBE_CPU_REQUEST=200m

--- a/sonarqube/chart/Chart.yaml
+++ b/sonarqube/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "10.6.0"
+appVersion: "10.7.0"

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG sonarVersion=10.6.0
+ARG sonarVersion=10.7.0
 ARG sonarEdition=community
 
 FROM sonarqube:${sonarVersion}-${sonarEdition}

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -6,14 +6,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}
 ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
-SONAR_VERSION=10.6.0
+SONAR_VERSION=10.7.0
 SONAR_EDITION="community"
 
 function usage {
     printf "Test SonarQube setup.\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
-    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.6.0' (defaults to %s)\n" "${SONAR_VERSION}"
+    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.7.0' (defaults to %s)\n" "${SONAR_VERSION}"
     printf "\t-e|--sq-edition\t\tSonarQube edition, e.g. 'community' or 'enterprise' (defaults to %s)\n" "${SONAR_EDITION}"
     printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
     printf "\t--verify\t\tSkips setup of local docker container and instead checks existing sonarqube setup based on ods-core.env\n"


### PR DESCRIPTION
Update SonarQube to 10.7 non LTS version.

It would be better if we can include the upcoming new rust plugin version -> https://github.com/C4tWithShell/community-rust/pull/115

Test:
- [x] CI/CD pipeline scans successfully
- [ ] Ensure cnes report works properly -> Fails with version 5.0.0 of cnes report