### PR TITLE
Update SonarQube to version 10.8

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: ['10.6.0'] # 9.9 = LTS
+        version: ['10.7.0'] # 9.9 = LTS
         edition: ['community', 'developer', 'enterprise']
     steps:
       -

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        version: ['10.7.0'] # 9.9 = LTS
-        edition: ['community', 'developer', 'enterprise']
+        version: ['10.8.0'] # 9.9 = LTS
+        edition: ['developer', 'enterprise']
     steps:
       -
         name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Changed
 - Webhook Proxy maintenance ([#1298](https://github.com/opendevstack/ods-core/pull/1298))
-- Update SonarQube to 10.x non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
+- Update SonarQube to 10.6 non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
 - Jenkins maintenance ([#1299](https://github.com/opendevstack/ods-core/pull/1299)) and update java version in Jenkins ([#1295](https://github.com/opendevstack/ods-core/issues/1295))
+- Update SonarQube to 10.7 non LTS ([#1298](https://github.com/opendevstack/ods-core/pull/1309))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Webhook Proxy maintenance ([#1298](https://github.com/opendevstack/ods-core/pull/1298))
 - Update SonarQube to 10.6 non LTS ([#1300](https://github.com/opendevstack/ods-core/issues/1300))
 - Jenkins maintenance ([#1299](https://github.com/opendevstack/ods-core/pull/1299)) and update java version in Jenkins ([#1295](https://github.com/opendevstack/ods-core/issues/1295))
-- Update SonarQube to 10.7 non LTS ([#1298](https://github.com/opendevstack/ods-core/pull/1309))
+- Update SonarQube to 10.8 non LTS ([#1310](https://github.com/opendevstack/ods-core/pull/1310))
 
 ### Fixed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -130,12 +130,12 @@ SONAR_DATABASE_USER=sonarqube
 # See https://www.sonarsource.com/plans-and-pricing/.
 # - Use "community" for free edition
 # - Use "developer", "enterprise" or "datacenter" for commercial editions
-SONAR_EDITION=community
+SONAR_EDITION=developer
 # SonarQube version.
 # See Dockerhub https://hub.docker.com/_/sonarqube/tags
 # Officially supported is:
-# - 10.7.0
-SONAR_VERSION=10.7.0
+# - 10.8.0
+SONAR_VERSION=10.8.0
 
 # SonarQube memory and CPU resources
 SONARQUBE_CPU_REQUEST=200m

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -134,8 +134,8 @@ SONAR_EDITION=community
 # SonarQube version.
 # See Dockerhub https://hub.docker.com/_/sonarqube/tags
 # Officially supported is:
-# - 10.6.0
-SONAR_VERSION=10.6.0
+# - 10.7.0
+SONAR_VERSION=10.7.0
 
 # SonarQube memory and CPU resources
 SONARQUBE_CPU_REQUEST=200m

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -2,7 +2,7 @@ FROM quay.io/openshift/origin-jenkins-agent-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ENV SONAR_SCANNER_VERSION=6.1.0.4477 \
+ENV SONAR_SCANNER_VERSION=6.2.1.4610 \
     CNES_REPORT_VERSION=5.0.0 \
     TAILOR_VERSION=1.3.4 \
     SOPS_VERSION=3.9.0 \

--- a/sonarqube/chart/Chart.yaml
+++ b/sonarqube/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "10.6.0"
+appVersion: "10.7.0"

--- a/sonarqube/chart/Chart.yaml
+++ b/sonarqube/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "10.7.0"
+appVersion: "10.8.0"

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -1,6 +1,8 @@
-ARG sonarVersion=10.7.0
-ARG sonarEdition=community
+ARG sonarVersion=10.8.0
+ARG sonarEdition=developer
 
+# For community edition use the following:
+# FROM sonarqube:lts-community
 FROM sonarqube:${sonarVersion}-${sonarEdition}
 
 ARG APP_DNS
@@ -23,7 +25,7 @@ RUN mkdir -p /opt/configuration/sonarqube/plugins
 # Language plugins not bundled
 ADD https://github.com/Inform-Software/sonar-groovy/releases/download/1.8/sonar-groovy-plugin-1.8.jar /opt/configuration/sonarqube/plugins/
 ADD https://github.com/Merck/sonar-r-plugin/releases/download/0.2.2/sonar-r-plugin-0.2.2.jar /opt/configuration/sonarqube/plugins/
-ADD https://github.com/elegoff/sonar-rust/releases/download/v0.2.4/community-rust-plugin-0.2.4.jar /opt/configuration/sonarqube/plugins/
+ADD https://github.com/elegoff/sonar-rust/releases/download/v0.2.5/community-rust-plugin-0.2.5.jar /opt/configuration/sonarqube/plugins/
 
 COPY run.sh $SONARQUBE_HOME/bin/
 

--- a/sonarqube/docker/Dockerfile
+++ b/sonarqube/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG sonarVersion=10.6.0
+ARG sonarVersion=10.7.0
 ARG sonarEdition=community
 
 FROM sonarqube:${sonarVersion}-${sonarEdition}

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -6,14 +6,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}
 ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
-SONAR_VERSION=10.6.0
+SONAR_VERSION=10.7.0
 SONAR_EDITION="community"
 
 function usage {
     printf "Test SonarQube setup.\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
-    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.6.0' (defaults to %s)\n" "${SONAR_VERSION}"
+    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.7.0' (defaults to %s)\n" "${SONAR_VERSION}"
     printf "\t-e|--sq-edition\t\tSonarQube edition, e.g. 'community' or 'enterprise' (defaults to %s)\n" "${SONAR_EDITION}"
     printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
     printf "\t--verify\t\tSkips setup of local docker container and instead checks existing sonarqube setup based on ods-core.env\n"

--- a/sonarqube/test.sh
+++ b/sonarqube/test.sh
@@ -6,14 +6,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CORE_DIR=${SCRIPT_DIR%/*}
 ODS_CONFIGURATION_DIR="${ODS_CORE_DIR}/../ods-configuration"
 
-SONAR_VERSION=10.7.0
-SONAR_EDITION="community"
+SONAR_VERSION=10.8.0
+SONAR_EDITION="developer"
 
 function usage {
     printf "Test SonarQube setup.\n\n"
     printf "\t-h|--help\t\tPrint usage\n"
     printf "\t-v|--verbose\t\tEnable verbose mode\n"
-    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.7.0' (defaults to %s)\n" "${SONAR_VERSION}"
+    printf "\t-s|--sq-version\t\tSonarQube version, e.g. '10.8.0' (defaults to %s)\n" "${SONAR_VERSION}"
     printf "\t-e|--sq-edition\t\tSonarQube edition, e.g. 'community' or 'enterprise' (defaults to %s)\n" "${SONAR_EDITION}"
     printf "\t-i|--insecure\t\tAllow insecure server connections when using SSL\n"
     printf "\t--verify\t\tSkips setup of local docker container and instead checks existing sonarqube setup based on ods-core.env\n"
@@ -191,7 +191,7 @@ case $SONAR_EDITION in
     community | developer | enterprise | datacenter)
         expectedPlugins=("groovy:1.8"
                 "r:0.2.2"
-                "communityrust:0.2.4" )
+                "communityrust:0.2.5" )
         ;;
 
     *)


### PR DESCRIPTION
Update SonarQube to 10.8 non LTS version.

Test:
- [x] CI/CD pipeline scans successfully
- [x] Ensure cnes report works properly -> There is a warning but it is generating the report successfully
![image](https://github.com/user-attachments/assets/8b19b9f4-bd6f-48ef-9678-ca62d02656fb)

SonarQube made changes to the community edition (now called community build) and do not offer anymore an specific version for this, just latest. For this I have removed the community edition from the tests and just test developer and enterprise.
