### PR TITLE
Update Aqua version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Adde mask-passwords and office 365 connector plugins in Jenkins ([#1313](https://github.com/opendevstack/ods-core/issues/1313)) and ([#1316](https://github.com/opendevstack/ods-core/issues/1316))
 
 ### Changed
+- Updated Aqua CLI ([#1325](https://github.com/opendevstack/ods-core/pull/1325))
 
 ### Fixed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -250,8 +250,8 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # Releases are published at https://download.aquasec.com/scanner
 # Check Aqua versions backward compatibility at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
 # To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
-# Latest tested version is 2022.4.588
-# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.588/scannercli
+# Latest tested version is 2022.4.720
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.720/scannercli
 JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 # Repository of shared library


### PR DESCRIPTION
Update Aqua CLI version to 2022.4.720

Tests:
- [x] Component pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.588
- [x] Orchestration pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.588
- [x] Component pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.720
- [x] Orchestration pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.720