### PR TITLE
Maintenance March 2025

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -90,10 +90,10 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@v4.2.2
       -
-        name: Setup Go 1.23
+        name: Setup Go 1.24
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23
+          go-version: 1.24
       -
         name: Download goimports
         run: |

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -216,11 +216,11 @@ CONFLUENCE_URL=http://192.168.56.31:8090
 # Base image for Jenkins master.
 # For UBI8-based images (OpenShift 4):
 # - RHEL variant: https://catalog.redhat.com/software/containers/ocp-tools-4/jenkins-rhel8/5fe1f38288e9c2f788526306
-# -      Example: registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0
-# -      Last tested: registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0-1723454631
+# -      Example: registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.16.0
+# -      Last tested: registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.16.0-1739898511
 # - Community variant: https://quay.io/repository/openshift/origin-jenkins?tab=tags
 # -           Example: quay.io/openshift/origin-jenkins:4.6
-JENKINS_MASTER_BASE_FROM_IMAGE=registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0-1723454631
+JENKINS_MASTER_BASE_FROM_IMAGE=registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.16.0-1739898511
 
 # Dockerfile to use for Jenkins master.
 # Use "Dockerfile.ubi8" for both OpenShift 3.11 and 4  (UBI8 base image)
@@ -229,11 +229,11 @@ JENKINS_MASTER_DOCKERFILE_PATH=Dockerfile.ubi8
 # Base image for Jenkins agent base.
 # For UBI8-based images (OpenShift 4):
 # - RHEL variant: https://catalog.redhat.com/software/containers/ocp-tools-4/jenkins-agent-base-rhel8/6241e3457847116cf8577aea
-# -      Example: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.14.0
-# -      Last tested: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.14.0-1723453106
+# -      Example: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel9:v4.16.0
+# -      Last tested: registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel9:v4.16.0-1739896346
 # - Community variant: https://quay.io/repository/openshift/origin-jenkins-agent-base?tab=tags
 # -           Example: quay.io/openshift/origin-jenkins-agent-base:4.6
-JENKINS_AGENT_BASE_FROM_IMAGE=registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel8:v4.14.0-1723453106
+JENKINS_AGENT_BASE_FROM_IMAGE=registry.redhat.io/ocp-tools-4/jenkins-agent-base-rhel9:v4.16.0-1739896346
 
 # Dockerfile to use for Jenkins agents.
 # Use "Dockerfile.ubi8" for both OpenShift 3.11 and 4  (UBI8 base image)

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -45,8 +45,8 @@ ODS_BITBUCKET_PROJECT=opendevstack
 # Nexus base image
 # See Dockerhub https://hub.docker.com/r/sonatype/nexus3/tags.
 # Officially supported is:
-# - 3.70.3-java11-ubi
-NEXUS_IMAGE_TAG=3.70.3-java11-ubi
+# - 3.70.4-java11-ubi
+NEXUS_IMAGE_TAG=3.70.4-java11-ubi
 
 # Nexus host without protocol.
 # The domain should be equal to OPENSHIFT_APPS_BASEDOMAIN (see below).

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -116,7 +116,7 @@ SONAR_SAML_CERTIFICATE_B64=changeme
 # your SonarQube version, see https://docs.sonarqube.org/latest/requirements/requirements/.
 # Take care when upgrading either database or SQ version.
 # E.g. registry.redhat.io/rhel9/postgresql-15
-SONAR_DATABASE_IMAGE=docker-registry.default.svc:5000/openshift/postgresql:15
+SONAR_DATABASE_IMAGE=docker-registry.redhat.io/rhel9/postgresql-16
 # Connection string for JDBC. Typically this does not need to be changed.
 SONAR_DATABASE_JDBC_URL=jdbc:postgresql://sonarqube-postgresql:5432/sonarqube
 # Database name for SonarQube. Typically this does not need to be changed.
@@ -134,8 +134,8 @@ SONAR_EDITION=developer
 # SonarQube version.
 # See Dockerhub https://hub.docker.com/_/sonarqube/tags
 # Officially supported is:
-# - 10.8.0
-SONAR_VERSION=10.8.0
+# - 2025.1.0
+SONAR_VERSION=2025.1.0
 
 # SonarQube memory and CPU resources
 SONARQUBE_CPU_REQUEST=200m

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -242,8 +242,8 @@ JENKINS_AGENT_DOCKERFILE_PATH=Dockerfile.ubi8
 # Snyk CLI binary distribution url
 # Leave empty to avoid installing Snyk.
 # Releases are published at https://github.com/snyk/snyk/releases.
-# Latest tested version is v1.1292.4.
-JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.1292.4/snyk-linux
+# Latest tested version is v1.1295.4.
+JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/download/v1.1295.4/snyk-linux
 
 # AquaSec CLI binary distribution url
 # Leave empty to avoid installing AquaSec.

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -2,16 +2,16 @@ FROM quay.io/openshift/origin-jenkins-agent-base
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ENV SONAR_SCANNER_VERSION=6.2.1.4610 \
-    CNES_REPORT_VERSION=5.0.0 \
+ENV SONAR_SCANNER_VERSION=7.0.2.4839 \
+    CNES_REPORT_VERSION=5.0.1 \
     TAILOR_VERSION=1.3.4 \
-    SOPS_VERSION=3.9.0 \
-    HELM_VERSION=3.15.4 \
-    HELM_PLUGIN_DIFF_VERSION=3.9.9 \
-    HELM_PLUGIN_SECRETS_VERSION=4.6.1 \
-    GIT_LFS_VERSION=3.5.1 \
+    SOPS_VERSION=3.9.4 \
+    HELM_VERSION=3.17.1 \
+    HELM_PLUGIN_DIFF_VERSION=3.10.0 \
+    HELM_PLUGIN_SECRETS_VERSION=4.6.3 \
+    GIT_LFS_VERSION=3.6.1 \
     IMGPKG_VERSION=0.44.0 \
-    TRIVY_VERSION=0.54.1 \
+    TRIVY_VERSION=0.60.0 \
     YQ_VERSION=4.45.1 \
     JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 

--- a/jenkins/master/plugins.ubi8.txt
+++ b/jenkins/master/plugins.ubi8.txt
@@ -1,18 +1,14 @@
 # Aditional plugins
-greenballs:1.15.1
-sonar:2.17.2
-ansicolor:1.0.4
-audit-trail:361.v82cde86c784e
-Office-365-Connector:5.0.0
-mask-passwords:173.v6a_077a_291eb_5
-
-# Plugins updated to fix dependecy errors (can be removed in next version)
-workflow-step-api:657.v03b_e8115821b_
+sonar:2.18
+ansicolor:1.0.6
+audit-trail:382.vf64d6f626060
+Office-365-Connector:5.1.0
+mask-passwords:188.v66e477dcb_24a_
 
 # Bundled plugins
-token-macro:400.v35420b_922dcb_
-email-ext:2.104
-junit:1265.v65b_14fa_f12f0
-blueocean:1.27.9
-kubernetes:4174.v4230d0ccd951
-openshift-sync:1.1.0.802.v45585f8cdc07
+# token-macro:400.v35420b_922dcb_
+# email-ext:2.104
+# junit:1265.v65b_14fa_f12f0
+# blueocean:1.27.9
+# kubernetes:4174.v4230d0ccd951
+# openshift-sync:1.1.0.802.v45585f8cdc07

--- a/jenkins/webhook-proxy/Dockerfile
+++ b/jenkins/webhook-proxy/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM public.ecr.aws/docker/library/golang:1.23-alpine AS builder
+FROM public.ecr.aws/docker/library/golang:1.24-alpine AS builder
 
 RUN apk update  && \
     apk -i upgrade && \

--- a/jenkins/webhook-proxy/Makefile
+++ b/jenkins/webhook-proxy/Makefile
@@ -8,7 +8,7 @@ fmt:
 
 lint:
 	golangci-lint --version
-	golangci-lint run --go=1.23
+	golangci-lint run --go=1.24
 
 build: build-linux build-darwin build-windows
 

--- a/jenkins/webhook-proxy/go.mod
+++ b/jenkins/webhook-proxy/go.mod
@@ -1,3 +1,3 @@
 module github.com/opendevstack/ods-core/jenkins/webhook-proxy
 
-go 1.23
+go 1.24

--- a/jenkins/webhook-proxy/main.go
+++ b/jenkins/webhook-proxy/main.go
@@ -93,10 +93,6 @@ type buildConfig struct {
         } `json:"strategy"`
         Triggers []struct {
             Type string `json:"type"`
-            // Generic struct {
-            //     Secret string `json:"secret"`
-            //     AllowEnv bool `json:"allowEnv"`
-            // } `json:"generic"`
         } `json:"triggers"`
     } `json:"spec"`
 }

--- a/nexus/chart/Chart.yaml
+++ b/nexus/chart/Chart.yaml
@@ -21,4 +21,4 @@ version: 1.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.70.3-java11-ubi"
+appVersion: "3.70.4-java11-ubi"

--- a/sonarqube/chart/Chart.yaml
+++ b/sonarqube/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "10.8.0"
+appVersion: "2025.1.0"


### PR DESCRIPTION
**Updated:**
- Jenkins to new rhel9 image. Jenkins agent packages and server plugins versions updated
- Webhoom proxy to Golang 1.24
- Nexus updated to 3.70.4
- SonarQube updated to 2025.1, and PostgreSQL 16

**Tests:**

- [ ] Jenkins agent and server image build and deploy
- [ ] Webhook proxy image build and deploy
- [ ] Nexus image build and deploy
- [ ] SonarQube image build and deploy