### PR TITLE
Update Aqua version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add package cosign ([#1323](https://github.com/opendevstack/ods-core/issues/1323))
 
 ### Changed
-- Updated Aqua CLI ([#1325](https://github.com/opendevstack/ods-core/pull/1325))
+- Updated Aqua CLI ([#1325](https://github.com/opendevstack/ods-core/pull/1325)) & ([#1332](https://github.com/opendevstack/ods-core/pull/1332))
 
 ### Fixed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -251,7 +251,7 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # Check Aqua versions backward compatibility at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
 # To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
 # Latest tested version is 2022.4.720
-# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.720/scannercli
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.759/scannercli
 JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 # Repository of shared library


### PR DESCRIPTION
Update Aqua CLI version to 2022.4.759, using server version 2022.4.759

Tests:
- [x] Component pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.588
- [x] Orchestration pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.588
- [x] Component pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.759
- [x] Orchestration pipeline with vulnerable package, including whitelisting it. Pipeline fails when not whitelisted. Using CLI version 2022.4.759