### PR TITLE
Update Go mod to use 1.N.P syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Webhook proxy BC recretion issue ([#1265](https://github.com/opendevstack/ods-core/issues/1265))
+- Fix Go version without 1.N.P syntax ([#1337](https://github.com/opendevstack/ods-core/pull/1337))
 
 ## [4.7.0] - 2025-1-27
 

--- a/jenkins/webhook-proxy/go.mod
+++ b/jenkins/webhook-proxy/go.mod
@@ -1,3 +1,3 @@
 module github.com/opendevstack/ods-core/jenkins/webhook-proxy
 
-go 1.24
+go 1.24.1


### PR DESCRIPTION
Fix CodeQL-Build warning

As of Go 1.21, toolchain versions [must use the 1.N.P syntax](https://go.dev/doc/toolchain#version).

1.24 in jenkins/webhook-proxy/go.mod does not match this syntax and there is no additional toolchain directive, which may cause some go commands to fail.