### PR TITLE
update Aqua CLI to 760 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Security improvements ([#1328](https://github.com/opendevstack/ods-core/pull/1328))
 
+- Update Aqua cli to 760 ([#1344](https://github.com/opendevstack/ods-core/pull/1344))
+
 ### Fixed
 
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -267,8 +267,8 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # Releases are published at https://download.aquasec.com/scanner
 # Check Aqua versions backward compatibility at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
 # To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
-# Latest tested version is 2022.4.720
-# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.759/scannercli
+# Latest tested version is 2022.4.760
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.760/scannercli
 JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 # Repository of shared library


### PR DESCRIPTION
Update Aqua CLI to 2022.4.760 version

Tests:
- [x] Component pipeline with 2022.4.760 successfully
- [x] Report generated successfully
- [x] Code Insights generated successfully
- [x] When vul is intended, pipeline is stoped