### PR TITLE
Update Aqua CLI to 2022.4.829

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Adapted Sonarqube server configuration to make projects private and have custom gate ([#1347](https://github.com/opendevstack/ods-core/pull/1347))
+- Update Aqua cli to 2022.4.829 ([#1353](https://github.com/opendevstack/ods-core/pull/1353))
 
 ### Fixed
 

--- a/configuration-sample/ods-core.env.sample
+++ b/configuration-sample/ods-core.env.sample
@@ -282,8 +282,8 @@ JENKINS_AGENT_BASE_SNYK_DISTRIBUTION_URL=https://github.com/snyk/snyk/releases/d
 # Releases are published at https://download.aquasec.com/scanner
 # Check Aqua versions backward compatibility at https://docs.aquasec.com/docs/version-compatibility-of-components#section-backward-compatibility-across-two-major-versions
 # To Download the aquaSec scanner cli and check their documentaion requires a valid account on aquasec.com
-# Latest tested version is 2022.4.760
-# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.760/scannercli
+# Latest tested version is 2022.4.829
+# Example: https://<USER>:<PASSWORD>@download.aquasec.com/scanner/2022.4.829/scannercli
 JENKINS_AGENT_BASE_AQUASEC_SCANNERCLI_URL=
 
 # Repository of shared library


### PR DESCRIPTION
Tests:
- [x] Whitelisting vuls
- [x] Vuls fail pipeline and remove image
- [x] No vuls