### PR TITLE
Update TRIVY_VERSION to 0.69.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+## [4.12.2] - 2026-04-28
+### Changed
+- Update TRIVY_VERSION to 0.69.3 ([#1376](https://github.com/opendevstack/ods-core/pull/1376))
+
 ## [4.12.1] - 2026-03-03
 ### Fixed
 - Fix api service dockerfile ([#1372](https://github.com/opendevstack/ods-core/pull/1372))

--- a/jenkins/agent-base/Dockerfile.ubi8
+++ b/jenkins/agent-base/Dockerfile.ubi8
@@ -12,7 +12,7 @@ ENV SONAR_SCANNER_VERSION=7.3.0.5189 \
     HELM_PLUGIN_SECRETS_VERSION=4.6.1 \
     GIT_LFS_VERSION=3.5.1 \
     IMGPKG_VERSION=0.44.0 \
-    TRIVY_VERSION=0.54.1 \
+    TRIVY_VERSION=0.69.3 \
     YQ_VERSION=4.45.1 \
     JAVA_GC_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
 


### PR DESCRIPTION
We need to update the trivy version to rebuild OpenDevstack as the older version do not exist anymore (removed by hackers in trivy repository/org)