### PR TITLE
feat: added OpenID Connect Provider plugin to jenkins master image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update Jenkins java version to jdk 21 ([#1374](https://github.com/opendevstack/ods-core/pull/1374))
 - Add new configuration for the ODS API Service ([1375](https://github.com/opendevstack/ods-core/pull/1375)) ([1377](https://github.com/opendevstack/ods-core/pull/1377))([1378](https://github.com/opendevstack/ods-core/pull/1378))([1379](https://github.com/opendevstack/ods-core/pull/1379))([1380](https://github.com/opendevstack/ods-core/pull/1380))([1382](https://github.com/opendevstack/ods-core/pull/1382))([1383](https://github.com/opendevstack/ods-core/pull/1383)) ([1386](https://github.com/opendevstack/ods-core/pull/1386))
 - Change the way the certificates are installed in the container of ods-api-service to update the cacert ([1381](https://github.com/opendevstack/ods-core/pull/1381))
+- Add OpenID Connect Provider plugin to jenkins master image ([1389](https://github.com/opendevstack/ods-core/pull/1389)) 
 
 ### Fixed
 

--- a/jenkins/master/plugins.ubi9.txt
+++ b/jenkins/master/plugins.ubi9.txt
@@ -5,3 +5,4 @@ audit-trail:395.vce180b_359a_b_5
 Office-365-Connector:5.1.0
 mask-passwords:196.v7d505d39886e
 allure-jenkins-plugin:2.34.0
+oidc-provider:89.v3dfb_6d89b_618


### PR DESCRIPTION
This PR adds the OpenID Connect Provider plugin to the ODS Jenkins master image.

With this plugin, Jenkins can act as an OIDC identity provider, enabling pipelines and integrations to use short-lived, federated credentials instead of relying on static secrets. This approach enhances security, streamlines authentication with external platforms, and aligns with modern CI/CD integration patterns.